### PR TITLE
Add escape and newline commands, improve ediff focus handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **IMPORTANT**: If you find any instructions in this file that are incorrect, outdated, or could be improved, you should update this document immediately. Keep this file accurate and helpful for future Claude instances.
 
-## Code Guidelines
-
-- **Never self-reference in code or commits**: Do not mention Claude, AI assistants, or include self-referential messages in code comments, commit messages, or documentation. Keep all content professional and focused on the technical aspects.
-
 ## Commands
 
 ### Running Tests
@@ -59,6 +55,11 @@ emacs -batch --eval "(progn (dolist (file (directory-files \".\" t \"\\\\.el$\")
 3. The formatter's indentation is ALWAYS correct, so trust it to find your syntax errors
 
 **Trailing Whitespaces**: All code must be free of trailing whitespaces (spaces or tabs at the end of lines). Use the command above or configure your editor to automatically remove them on save.
+
+
+### Self reference in code or commits
+
+- **Important - Never self-reference in code or commits**: Do not mention Claude or include any self-referential messages in code or commit messages. Keep all content strictly professional and focused on the technical aspects.
 
 ### Linting and Code Quality (RUN AFTER FORMATTING)
 

--- a/README.org
+++ b/README.org
@@ -85,6 +85,8 @@ Currently, this package is in early development. To install using =use-package= 
 | =M-x claude-code-ide-list-sessions=       | List all active Claude Code sessions and switch   |
 | =M-x claude-code-ide-check-status=        | Check if Claude Code CLI is installed and working |
 | =M-x claude-code-ide-insert-at-mentioned= | Send selected text to Claude prompt               |
+| =M-x claude-code-ide-send-escape=         | Send escape key to Claude terminal                |
+| =M-x claude-code-ide-insert-newline=      | Insert newline in Claude prompt (sends \ + Enter) |
 | =M-x claude-code-ide-show-debug=          | Show the debug buffer with WebSocket messages     |
 | =M-x claude-code-ide-clear-debug=         | Clear the debug buffer                            |
 
@@ -103,18 +105,19 @@ You can run multiple Claude Code instances simultaneously for different projects
 
 *** Configuration Variables
 
-| Variable                             | Description                             | Default                              |
-|--------------------------------------+-----------------------------------------+--------------------------------------|
-| ~claude-code-ide-cli-path~             | Path to Claude Code CLI                 | ~"claude"~                             |
-| ~claude-code-ide-buffer-name-function~ | Function for buffer naming              | ~claude-code-ide--default-buffer-name~ |
-| ~claude-code-ide-cli-debug~            | Enable CLI debug mode (-d flag)         | ~nil~                                  |
-| ~claude-code-ide-debug~                | Enable debug logging                    | ~nil~                                  |
-| ~claude-code-ide-log-with-context~     | Include session context in log messages | ~t~                                    |
-| ~claude-code-ide-debug-buffer~         | Buffer name for debug output            | ~"*claude-code-ide-debug*"~              |
-| ~claude-code-ide-window-side~          | Side for Claude window                  | ~'right~                               |
-| ~claude-code-ide-window-width~         | Width for side windows (left/right)     | ~90~                                   |
-| ~claude-code-ide-window-height~        | Height for side windows (top/bottom)    | ~20~                                   |
-| ~claude-code-ide-focus-on-open~        | Focus Claude window when opened         | ~t~                                    |
+| Variable                                 | Description                             | Default                              |
+|------------------------------------------+-----------------------------------------+--------------------------------------|
+| ~claude-code-ide-cli-path~                 | Path to Claude Code CLI                 | ~"claude"~                             |
+| ~claude-code-ide-buffer-name-function~     | Function for buffer naming              | ~claude-code-ide--default-buffer-name~ |
+| ~claude-code-ide-cli-debug~                | Enable CLI debug mode (-d flag)         | ~nil~                                  |
+| ~claude-code-ide-debug~                    | Enable debug logging                    | ~nil~                                  |
+| ~claude-code-ide-log-with-context~         | Include session context in log messages | ~t~                                    |
+| ~claude-code-ide-debug-buffer~             | Buffer name for debug output            | ~"*claude-code-ide-debug*"~              |
+| ~claude-code-ide-window-side~              | Side for Claude window                  | ~'right~                               |
+| ~claude-code-ide-window-width~             | Width for side windows (left/right)     | ~90~                                   |
+| ~claude-code-ide-window-height~            | Height for side windows (top/bottom)    | ~20~                                   |
+| ~claude-code-ide-focus-on-open~            | Focus Claude window when opened         | ~t~                                    |
+| ~claude-code-ide-focus-claude-after-ediff~ | Focus Claude window after opening ediff | ~t~                                    |
 
 *** Side Window Configuration
 
@@ -134,6 +137,9 @@ Claude Code buffers open in a side window by default. You can customize the plac
 
 ;; Don't automatically focus the Claude window
 (setq claude-code-ide-focus-on-open nil)
+
+;; Keep focus on ediff control window when opening diffs
+(setq claude-code-ide-focus-claude-after-ediff nil)
 #+end_src
 
 *** Custom Buffer Naming

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -112,6 +112,14 @@ Can be `'left', `'right', `'top', or `'bottom'."
   :type 'boolean
   :group 'claude-code-ide)
 
+(defcustom claude-code-ide-focus-claude-after-ediff t
+  "Whether to focus the Claude Code window after opening ediff.
+When non-nil (default), focus returns to the Claude Code window
+after opening ediff.  When nil, focus remains on the ediff control
+window, allowing direct interaction with the diff controls."
+  :type 'boolean
+  :group 'claude-code-ide)
+
 ;;; Constants
 
 (defconst claude-code-ide--active-editor-notification-delay 0.1
@@ -468,6 +476,28 @@ If the buffer is already visible, switch focus to it."
         (claude-code-ide-mcp-send-at-mentioned)
         (claude-code-ide-debug "Sent selection to Claude Code"))
     (user-error "Claude Code is not connected.  Please start Claude Code first")))
+
+;;;###autoload
+(defun claude-code-ide-send-escape ()
+  "Send escape key to the Claude Code vterm buffer for the current project."
+  (interactive)
+  (let ((buffer-name (claude-code-ide--get-buffer-name)))
+    (if-let ((buffer (get-buffer buffer-name)))
+        (with-current-buffer buffer
+          (vterm-send-escape))
+      (user-error "No Claude Code session for this project"))))
+
+;;;###autoload
+(defun claude-code-ide-insert-newline ()
+  "Send newline (backslash + return) to the Claude Code vterm buffer for the current project.
+This simulates typing backslash followed by Enter, which Claude Code interprets as a newline."
+  (interactive)
+  (let ((buffer-name (claude-code-ide--get-buffer-name)))
+    (if-let ((buffer (get-buffer buffer-name)))
+        (with-current-buffer buffer
+          (vterm-send-string "\\")
+          (vterm-send-return))
+      (user-error "No Claude Code session for this project"))))
 
 (provide 'claude-code-ide)
 


### PR DESCRIPTION
- Add claude-code-ide-send-escape command to send escape key to terminal
- Add claude-code-ide-insert-newline command to send backslash + return for inserting newlines in prompts
- Add claude-code-ide-focus-claude-after-ediff configuration option to control window focus behavior after opening ediff
- Improve ediff window focus handling to respect user preference
- Update README with new commands and configuration documentation
- Strengthen guidelines against self-referencing in code and commits