### PR TITLE
Add customizable CLI flags support

### DIFF
--- a/README.org
+++ b/README.org
@@ -110,6 +110,7 @@ You can run multiple Claude Code instances simultaneously for different projects
 | ~claude-code-ide-cli-path~                 | Path to Claude Code CLI                 | ~"claude"~                             |
 | ~claude-code-ide-buffer-name-function~     | Function for buffer naming              | ~claude-code-ide--default-buffer-name~ |
 | ~claude-code-ide-cli-debug~                | Enable CLI debug mode (-d flag)         | ~nil~                                  |
+| ~claude-code-ide-cli-extra-flags~          | Additional CLI flags (e.g. "--model")   | ~""~                                   |
 | ~claude-code-ide-debug~                    | Enable debug logging                    | ~nil~                                  |
 | ~claude-code-ide-log-with-context~         | Include session context in log messages | ~t~                                    |
 | ~claude-code-ide-debug-buffer~             | Buffer name for debug output            | ~"*claude-code-ide-debug*"~              |
@@ -153,6 +154,22 @@ You can customize how Claude Code buffers are named:
             (format "*Claude:%s*" (file-name-nondirectory (directory-file-name directory)))
           "*Claude:Global*")))
 #+end_src
+
+*** Custom CLI Flags
+
+You can pass additional flags to the Claude Code CLI:
+
+#+begin_src emacs-lisp
+;; Use a specific model
+(setq claude-code-ide-cli-extra-flags "--model opus")
+
+;; Pass multiple flags
+(setq claude-code-ide-cli-extra-flags "--model opus --no-cache")
+
+;; Flags are added to all Claude Code sessions
+#+end_src
+
+Note: These flags are appended to the Claude command after any built-in flags like =-d= (debug) or =-r= (resume).
 
 *** Debugging
 

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -88,6 +88,12 @@ and should return a string to use as the buffer name."
   :type 'boolean
   :group 'claude-code-ide)
 
+(defcustom claude-code-ide-cli-extra-flags ""
+  "Additional flags to pass to the Claude Code CLI.
+This should be a string of space-separated flags, e.g. \"--model opus\"."
+  :type 'string
+  :group 'claude-code-ide)
+
 (defcustom claude-code-ide-window-side 'right
   "Side of the frame where the Claude Code window should appear.
 Can be `'left', `'right', `'top', or `'bottom'."
@@ -270,7 +276,8 @@ If the window is not visible, it will be shown in a side window."
 (defun claude-code-ide--build-claude-command (&optional resume)
   "Build the Claude command with optional flags.
 If RESUME is non-nil, add the -r flag.
-If `claude-code-ide-cli-debug' is non-nil, add the -d flag."
+If `claude-code-ide-cli-debug' is non-nil, add the -d flag.
+Additional flags from `claude-code-ide-cli-extra-flags' are also included."
   (let ((claude-cmd claude-code-ide-cli-path))
     ;; Add debug flag if enabled
     (when claude-code-ide-cli-debug
@@ -278,6 +285,10 @@ If `claude-code-ide-cli-debug' is non-nil, add the -d flag."
     ;; Add resume flag if requested
     (when resume
       (setq claude-cmd (concat claude-cmd " -r")))
+    ;; Add any extra flags
+    (when (and claude-code-ide-cli-extra-flags
+               (not (string-empty-p claude-code-ide-cli-extra-flags)))
+      (setq claude-cmd (concat claude-cmd " " claude-code-ide-cli-extra-flags)))
     claude-cmd))
 
 (defun claude-code-ide--create-vterm-session (buffer-name working-dir port resume)


### PR DESCRIPTION
## Summary
- Added `claude-code-ide-cli-extra-flags` customization variable to allow users to pass additional flags to the Claude CLI
- Updated `claude-code-ide--build-claude-command` function to include the extra flags when building the command
- Users can now customize Claude CLI behavior with flags like `--model`

## Example Usage
```elisp
;; Set custom Claude executable path
(setq claude-code-ide-cli-path "/usr/local/bin/claude")

;; Enable debug mode
(setq claude-code-ide-cli-debug t)

;; Add custom flags
(setq claude-code-ide-cli-extra-flags "--model opus")
```

## Test Plan
- [x] Added new customization variable with proper docstring
- [x] Updated command building function to append extra flags
- [x] Tested that flags are properly concatenated to the command
- [x] Manual testing with actual Claude CLI to verify flags work as expected