### PR TITLE
Add option to hide Claude window during ediff

### DIFF
--- a/README.org
+++ b/README.org
@@ -130,25 +130,26 @@ You can run multiple Claude Code instances simultaneously for different projects
 
 *** Configuration Variables
 
-| Variable                                 | Description                             | Default                              |
-|------------------------------------------+-----------------------------------------+--------------------------------------|
-| ~claude-code-ide-cli-path~                 | Path to Claude Code CLI                 | ~"claude"~                             |
-| ~claude-code-ide-buffer-name-function~     | Function for buffer naming              | ~claude-code-ide--default-buffer-name~ |
-| ~claude-code-ide-cli-debug~                | Enable CLI debug mode (-d flag)         | ~nil~                                  |
-| ~claude-code-ide-cli-extra-flags~          | Additional CLI flags (e.g. "--model")   | ~""~                                   |
-| ~claude-code-ide-debug~                    | Enable debug logging                    | ~nil~                                  |
-| ~claude-code-ide-log-with-context~         | Include session context in log messages | ~t~                                    |
-| ~claude-code-ide-debug-buffer~             | Buffer name for debug output            | ~"*claude-code-ide-debug*"~              |
-| ~claude-code-ide-use-side-window~          | Use side window vs regular buffer       | ~t~                                    |
-| ~claude-code-ide-window-side~              | Side for Claude window                  | ~'right~                               |
-| ~claude-code-ide-window-width~             | Width for side windows (left/right)     | ~90~                                   |
-| ~claude-code-ide-window-height~            | Height for side windows (top/bottom)    | ~20~                                   |
-| ~claude-code-ide-focus-on-open~            | Focus Claude window when opened         | ~t~                                    |
-| ~claude-code-ide-focus-claude-after-ediff~ | Focus Claude window after opening ediff | ~t~                                    |
-| ~claude-code-ide-system-prompt~            | Custom system prompt to append          | ~nil~                                  |
-| ~claude-code-ide-enable-mcp-server~        | Enable MCP tools server                 | ~nil~                                  |
-| ~claude-code-ide-mcp-server-port~          | Port for MCP tools server               | ~nil~ (auto-select)                    |
-| ~claude-code-ide-mcp-server-tools~         | Alist of exposed Emacs functions        | ~nil~                                  |
+| Variable                                    | Description                             | Default                              |
+|---------------------------------------------+-----------------------------------------+--------------------------------------|
+| ~claude-code-ide-cli-path~                    | Path to Claude Code CLI                 | ~"claude"~                             |
+| ~claude-code-ide-buffer-name-function~        | Function for buffer naming              | ~claude-code-ide--default-buffer-name~ |
+| ~claude-code-ide-cli-debug~                   | Enable CLI debug mode (-d flag)         | ~nil~                                  |
+| ~claude-code-ide-cli-extra-flags~             | Additional CLI flags (e.g. "--model")   | ~""~                                   |
+| ~claude-code-ide-debug~                       | Enable debug logging                    | ~nil~                                  |
+| ~claude-code-ide-log-with-context~            | Include session context in log messages | ~t~                                    |
+| ~claude-code-ide-debug-buffer~                | Buffer name for debug output            | ~"*claude-code-ide-debug*"~              |
+| ~claude-code-ide-use-side-window~             | Use side window vs regular buffer       | ~t~                                    |
+| ~claude-code-ide-window-side~                 | Side for Claude window                  | ~'right~                               |
+| ~claude-code-ide-window-width~                | Width for side windows (left/right)     | ~90~                                   |
+| ~claude-code-ide-window-height~               | Height for side windows (top/bottom)    | ~20~                                   |
+| ~claude-code-ide-focus-on-open~               | Focus Claude window when opened         | ~t~                                    |
+| ~claude-code-ide-focus-claude-after-ediff~    | Focus Claude window after opening ediff | ~t~                                    |
+| ~claude-code-ide-show-claude-window-in-ediff~ | Show Claude window during ediff         | ~t~                                    |
+| ~claude-code-ide-system-prompt~               | Custom system prompt to append          | ~nil~                                  |
+| ~claude-code-ide-enable-mcp-server~           | Enable MCP tools server                 | ~nil~                                  |
+| ~claude-code-ide-mcp-server-port~             | Port for MCP tools server               | ~nil~ (auto-select)                    |
+| ~claude-code-ide-mcp-server-tools~            | Alist of exposed Emacs functions        | ~nil~                                  |
 
 *** Side Window Configuration
 
@@ -171,6 +172,9 @@ Claude Code buffers open in a side window by default. You can customize the plac
 
 ;; Keep focus on ediff control window when opening diffs
 (setq claude-code-ide-focus-claude-after-ediff nil)
+
+;; Hide Claude window during ediff for more screen space
+(setq claude-code-ide-show-claude-window-in-ediff nil)
 #+end_src
 
 Or, if you'd prefer to use a regular window:

--- a/claude-code-ide-mcp-handlers.el
+++ b/claude-code-ide-mcp-handlers.el
@@ -52,6 +52,8 @@
 (defvar ediff-split-window-function)
 (defvar ediff-control-buffer-suffix)
 (defvar claude-code-ide-mcp--sessions)
+(defvar claude-code-ide-show-claude-window-in-ediff)
+(defvar claude-code-ide-focus-claude-after-ediff)
 
 ;;; Tool Registry - Define variables first to ensure they're available
 
@@ -201,16 +203,17 @@ STARTUP-HOOK-FN is the hook function to remove after use."
     ;; Save the current window before any operations
     (let ((original-window (selected-window))
           (claude-window nil))
-      ;; Restore Claude side window (since we deleted all side windows before ediff)
-      (when-let* ((claude-buffer-name (claude-code-ide--get-buffer-name))
-                  (claude-buffer (get-buffer claude-buffer-name)))
-        (when (buffer-live-p claude-buffer)
-          ;; Display Claude buffer in side window and save the window
-          (setq claude-window (claude-code-ide--display-buffer-in-side-window claude-buffer))))
+      ;; Restore Claude side window only if user wants it shown during ediff
+      (when claude-code-ide-show-claude-window-in-ediff
+        (when-let* ((claude-buffer-name (claude-code-ide--get-buffer-name))
+                    (claude-buffer (get-buffer claude-buffer-name)))
+          (when (buffer-live-p claude-buffer)
+            ;; Display Claude buffer in side window and save the window
+            (setq claude-window (claude-code-ide--display-buffer-in-side-window claude-buffer)))))
 
       ;; Handle focus based on user preference
       (cond
-       ;; If user wants Claude window focus (default), select it
+       ;; If user wants Claude window focus and it's visible, select it
        ((and claude-code-ide-focus-claude-after-ediff claude-window)
         (select-window claude-window))
        ;; Otherwise, restore the original window (which might be one of the ediff windows)

--- a/claude-code-ide-transient.el
+++ b/claude-code-ide-transient.el
@@ -64,6 +64,7 @@
 (defvar claude-code-ide-window-height)
 (defvar claude-code-ide-focus-on-open)
 (defvar claude-code-ide-focus-claude-after-ediff)
+(defvar claude-code-ide-show-claude-window-in-ediff)
 (defvar claude-code-ide-use-side-window)
 (defvar claude-code-ide-cli-debug)
 (defvar claude-code-ide-cli-extra-flags)
@@ -263,6 +264,12 @@ Otherwise, if multiple sessions exist, prompt for selection."
   (setq claude-code-ide-focus-claude-after-ediff (not claude-code-ide-focus-claude-after-ediff))
   (claude-code-ide-log "Focus after ediff %s" (if claude-code-ide-focus-claude-after-ediff "enabled" "disabled")))
 
+(transient-define-suffix claude-code-ide--toggle-show-claude-in-ediff ()
+  "Toggle showing Claude window during ediff."
+  (interactive)
+  (setq claude-code-ide-show-claude-window-in-ediff (not claude-code-ide-show-claude-window-in-ediff))
+  (claude-code-ide-log "Show Claude window in ediff %s" (if claude-code-ide-show-claude-window-in-ediff "enabled" "disabled")))
+
 (transient-define-suffix claude-code-ide--toggle-use-side-window ()
   "Toggle use side window setting."
   (interactive)
@@ -283,6 +290,7 @@ Otherwise, if multiple sessions exist, prompt for selection."
   (customize-save-variable 'claude-code-ide-window-height claude-code-ide-window-height)
   (customize-save-variable 'claude-code-ide-focus-on-open claude-code-ide-focus-on-open)
   (customize-save-variable 'claude-code-ide-focus-claude-after-ediff claude-code-ide-focus-claude-after-ediff)
+  (customize-save-variable 'claude-code-ide-show-claude-window-in-ediff claude-code-ide-show-claude-window-in-ediff)
   (customize-save-variable 'claude-code-ide-use-side-window claude-code-ide-use-side-window)
   (customize-save-variable 'claude-code-ide-cli-path claude-code-ide-cli-path)
   (customize-save-variable 'claude-code-ide-cli-extra-flags claude-code-ide-cli-extra-flags)
@@ -326,6 +334,9 @@ Otherwise, if multiple sessions exist, prompt for selection."
     ("e" "Toggle focus after ediff" claude-code-ide--toggle-focus-after-ediff
      :description (lambda () (format "Focus after ediff (%s)"
                                      (if claude-code-ide-focus-claude-after-ediff "ON" "OFF"))))
+    ("E" "Toggle show Claude in ediff" claude-code-ide--toggle-show-claude-in-ediff
+     :description (lambda () (format "Show Claude in ediff (%s)"
+                                     (if claude-code-ide-show-claude-window-in-ediff "ON" "OFF"))))
     ("u" "Toggle side window" claude-code-ide--toggle-use-side-window
      :description (lambda () (format "Use side window (%s)"
                                      (if claude-code-ide-use-side-window "ON" "OFF"))))]

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -160,6 +160,15 @@ window, allowing direct interaction with the diff controls."
   :type 'boolean
   :group 'claude-code-ide)
 
+(defcustom claude-code-ide-show-claude-window-in-ediff t
+  "Whether to show the Claude Code side window when viewing diffs.
+When non-nil (default), the Claude Code side window is restored
+after opening ediff.  When nil, the Claude Code window remains
+hidden during diff viewing, giving you more screen space for the
+diff comparison."
+  :type 'boolean
+  :group 'claude-code-ide)
+
 (defcustom claude-code-ide-use-side-window t
   "Whether to display Claude Code in a side window.
 When non-nil (default), Claude Code opens in a dedicated side window


### PR DESCRIPTION
- New defcustom `claude-code-ide-show-claude-window-in-ediff` controls whether the Claude Code side window is shown during diff viewing
- Added transient menu toggle (key 'E') for easy configuration