### PR TITLE
Change send escape key terminal binding to C-<escape>

### DIFF
--- a/README.org
+++ b/README.org
@@ -207,7 +207,7 @@ Claude Code IDE adds custom keybindings to the terminal for easier interaction:
 | Keybinding | Command                        | Description                          |
 |------------+--------------------------------+--------------------------------------|
 | =M-RET=      | =claude-code-ide-insert-newline= | Insert a newline in the prompt       |
-| =C-g=        | =claude-code-ide-send-escape=    | Send escape key to cancel operations |
+| =C-<escape>= | =claude-code-ide-send-escape=    | Send escape key to cancel operations |
 
 These keybindings are automatically set up for both =vterm= and =eat= backends and only apply within Claude Code terminal buffers.
 

--- a/claude-code-ide-mcp-http-server.el
+++ b/claude-code-ide-mcp-http-server.el
@@ -160,7 +160,7 @@ with the appropriate session context."
       request nil -32700 "Parse error"))
 
     (quit
-     (claude-code-ide-debug "Request cancelled by user (C-g)")
+     (claude-code-ide-debug "Request cancelled by user (C-<escape>)")
      (claude-code-ide-mcp-http-server--send-json-error
       request nil -32001 "Operation cancelled by user"))
 

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -251,17 +251,17 @@ environments."
   "Set up keybindings for the Claude Code terminal buffer.
 This function binds:
 - M-RET (Alt-Return) to insert a newline
-- C-g to send escape"
+- C-<escape> to send escape"
   (cond
    ((eq claude-code-ide-terminal-backend 'vterm)
     ;; For vterm, we set up local keybindings in vterm-mode-map
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
-    (local-set-key (kbd "C-g") #'claude-code-ide-send-escape))
+    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
    ((eq claude-code-ide-terminal-backend 'eat)
     ;; For eat, we need to modify the semi-char mode map which is the default
     ;; We use local-set-key to make it buffer-local
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
-    (local-set-key (kbd "C-g") #'claude-code-ide-send-escape))
+    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
    (t
     (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))
 


### PR DESCRIPTION
This prevents overriding needed C-g Emacs functionality.