### PR TITLE
Fix transient-define-prefix autoloading error

### DIFF
--- a/claude-code-ide-transient.el
+++ b/claude-code-ide-transient.el
@@ -298,7 +298,7 @@ Otherwise, if multiple sessions exist, prompt for selection."
 
 ;;; Transient Menus
 
-;;;###autoload
+;;;###autoload (autoload 'claude-code-ide-menu "claude-code-ide" "Claude Code IDE main menu." t)
 (transient-define-prefix claude-code-ide-menu ()
   "Claude Code IDE main menu."
   [:description claude-code-ide--session-status]

--- a/claude-code-ide-transient.el
+++ b/claude-code-ide-transient.el
@@ -298,7 +298,7 @@ Otherwise, if multiple sessions exist, prompt for selection."
 
 ;;; Transient Menus
 
-;;;###autoload (autoload 'claude-code-ide-menu "claude-code-ide" "Claude Code IDE main menu." t)
+;;;###autoload (autoload 'claude-code-ide-menu "claude-code-ide-transient" "Claude Code IDE main menu." t)
 (transient-define-prefix claude-code-ide-menu ()
   "Claude Code IDE main menu."
   [:description claude-code-ide--session-status]


### PR DESCRIPTION
Fixes error on Emacs start
`Error loading autoloads: (void-function transient-prefix)`

Check - https://github.com/magit/transient/issues/280