### PR TITLE
Don't set the value of other packages' variables

### DIFF
--- a/claude-code-ide-diagnostics.el
+++ b/claude-code-ide-diagnostics.el
@@ -42,7 +42,7 @@
 (declare-function claude-code-ide-mcp-session-project-dir "claude-code-ide-mcp" (session))
 
 ;; Flycheck declarations
-(defvar flycheck-current-errors nil)
+(defvar flycheck-current-errors)
 (declare-function flycheck-error-line "flycheck" (err))
 (declare-function flycheck-error-column "flycheck" (err))
 (declare-function flycheck-error-end-line "flycheck" (err))

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -67,11 +67,11 @@
 (require 'claude-code-ide-emacs-tools)
 
 ;; External variable declarations
-(defvar eat-terminal nil)
-(defvar vterm-shell nil)
-(defvar vterm-environment nil)
-(defvar eat-term-name nil)
-(defvar vterm--process nil)
+(defvar eat-terminal)
+(defvar vterm-shell)
+(defvar vterm-environment)
+(defvar eat-term-name)
+(defvar vterm--process)
 
 ;; External function declarations for vterm
 (declare-function vterm "vterm" (&optional arg))


### PR DESCRIPTION
It's necesary to defvar the variables defined by packages which are optional dependencies, but those defvars should not provide an initial value, since if claude-code-ide.el is loaded before those other packages, that initial value will be used rather than the other packages' initial values.