### PR TITLE
Update README.org with installation for emacs > 30 (vc:)

### DIFF
--- a/README.org
+++ b/README.org
@@ -81,7 +81,19 @@ Follow the installation instructions at [[https://docs.anthropic.com/en/docs/cla
 
 ** Installing the Emacs Package
 
-Currently, this package is in early development. To install using =use-package= and [[https://github.com/raxod502/straight.el][straight.el]]:
+Currently, this package is in early development.
+
+To install using =emacs-version= >= 30 and =use-package= with the =vc= binding:
+
+#+begin_src elisp
+(use-package claude-code-ide
+  :vc (:url "https://github.com/manzaltu/claude-code-ide.el.git" :rev :newest)
+  :bind ("C-c C-'" . claude-code-ide-menu) ; Set your favorite keybinding
+  :config
+  (claude-code-ide-emacs-tools-setup)) ; Optionally enable Emacs MCP tools
+#+end_src
+
+To install using =use-package= and [[https://github.com/raxod502/straight.el][straight.el]]:
 
 #+begin_src emacs-lisp
 (use-package claude-code-ide


### PR DESCRIPTION
Since emacs 30, use-package has the `vc` binding available, to fetch a package's source from a version control system like git. Adding it to the readme, if maybe helpful when not using straight.

https://www.gnu.org/software/emacs/manual/html_node/emacs/Fetching-Package-Sources.html