### PR TITLE
Generalize terminal initialization delay for all backends

### DIFF
--- a/README.org
+++ b/README.org
@@ -143,32 +143,32 @@ You can run multiple Claude Code instances simultaneously for different projects
 
 *** Configuration Variables
 
-| Variable                                    | Description                                 | Default                              |
-|---------------------------------------------+---------------------------------------------+--------------------------------------|
-| ~claude-code-ide-cli-path~                    | Path to Claude Code CLI                     | ~"claude"~                             |
-| ~claude-code-ide-buffer-name-function~        | Function for buffer naming                  | ~claude-code-ide--default-buffer-name~ |
-| ~claude-code-ide-cli-debug~                   | Enable CLI debug mode (-d flag)             | ~nil~                                  |
-| ~claude-code-ide-cli-extra-flags~             | Additional CLI flags (e.g. "--model")       | ~""~                                   |
-| ~claude-code-ide-debug~                       | Enable debug logging                        | ~nil~                                  |
-| ~claude-code-ide-terminal-backend~            | Terminal backend (vterm or eat)             | ~'vterm~                               |
-| ~claude-code-ide-vterm-anti-flicker~          | Enable vterm flicker reduction              | ~t~                                    |
-| ~claude-code-ide-vterm-render-delay~          | vterm render batching delay (seconds)       | ~0.005~                                |
-| ~claude-code-ide-eat-initialization-delay~    | Initialization delay for eat terminal       | ~0.1~                                  |
-| ~claude-code-ide-log-with-context~            | Include session context in log messages     | ~t~                                    |
-| ~claude-code-ide-debug-buffer~                | Buffer name for debug output                | ~"*claude-code-ide-debug*"~              |
-| ~claude-code-ide-use-side-window~             | Use side window vs regular buffer           | ~t~                                    |
-| ~claude-code-ide-window-side~                 | Side for Claude window                      | ~'right~                               |
-| ~claude-code-ide-window-width~                | Width for side windows (left/right)         | ~90~                                   |
-| ~claude-code-ide-window-height~               | Height for side windows (top/bottom)        | ~20~                                   |
-| ~claude-code-ide-focus-on-open~               | Focus Claude window when opened             | ~t~                                    |
-| ~claude-code-ide-focus-claude-after-ediff~    | Focus Claude window after opening ediff     | ~t~                                    |
-| ~claude-code-ide-show-claude-window-in-ediff~ | Show Claude window during ediff             | ~t~                                    |
-| ~claude-code-ide-system-prompt~               | Custom system prompt to append              | ~nil~                                  |
-| ~claude-code-ide-enable-mcp-server~           | Enable MCP tools server                     | ~nil~                                  |
-| ~claude-code-ide-mcp-server-port~             | Port for MCP tools server                   | ~nil~ (auto-select)                    |
-| ~claude-code-ide-mcp-server-tools~            | Alist of exposed Emacs functions            | ~nil~                                  |
-| ~claude-code-ide-diagnostics-backend~         | Diagnostics backend (auto/flycheck/flymake) | ~'auto~                                |
-| ~claude-code-ide-prevent-reflow-glitch~       | Prevent terminal reflow glitch (bug #1422)  | ~t~                                    |
+| Variable                                      | Description                                 | Default                              |
+|-----------------------------------------------+---------------------------------------------+--------------------------------------|
+| ~claude-code-ide-cli-path~                      | Path to Claude Code CLI                     | ~"claude"~                             |
+| ~claude-code-ide-buffer-name-function~          | Function for buffer naming                  | ~claude-code-ide--default-buffer-name~ |
+| ~claude-code-ide-cli-debug~                     | Enable CLI debug mode (-d flag)             | ~nil~                                  |
+| ~claude-code-ide-cli-extra-flags~               | Additional CLI flags (e.g. "--model")       | ~""~                                   |
+| ~claude-code-ide-debug~                         | Enable debug logging                        | ~nil~                                  |
+| ~claude-code-ide-terminal-backend~              | Terminal backend (vterm or eat)             | ~'vterm~                               |
+| ~claude-code-ide-vterm-anti-flicker~            | Enable vterm flicker reduction              | ~t~                                    |
+| ~claude-code-ide-vterm-render-delay~            | vterm render batching delay (seconds)       | ~0.005~                                |
+| ~claude-code-ide-terminal-initialization-delay~ | Initialization delay for terminals          | ~0.1~                                  |
+| ~claude-code-ide-log-with-context~              | Include session context in log messages     | ~t~                                    |
+| ~claude-code-ide-debug-buffer~                  | Buffer name for debug output                | ~"*claude-code-ide-debug*"~              |
+| ~claude-code-ide-use-side-window~               | Use side window vs regular buffer           | ~t~                                    |
+| ~claude-code-ide-window-side~                   | Side for Claude window                      | ~'right~                               |
+| ~claude-code-ide-window-width~                  | Width for side windows (left/right)         | ~90~                                   |
+| ~claude-code-ide-window-height~                 | Height for side windows (top/bottom)        | ~20~                                   |
+| ~claude-code-ide-focus-on-open~                 | Focus Claude window when opened             | ~t~                                    |
+| ~claude-code-ide-focus-claude-after-ediff~      | Focus Claude window after opening ediff     | ~t~                                    |
+| ~claude-code-ide-show-claude-window-in-ediff~   | Show Claude window during ediff             | ~t~                                    |
+| ~claude-code-ide-system-prompt~                 | Custom system prompt to append              | ~nil~                                  |
+| ~claude-code-ide-enable-mcp-server~             | Enable MCP tools server                     | ~nil~                                  |
+| ~claude-code-ide-mcp-server-port~               | Port for MCP tools server                   | ~nil~ (auto-select)                    |
+| ~claude-code-ide-mcp-server-tools~              | Alist of exposed Emacs functions            | ~nil~                                  |
+| ~claude-code-ide-diagnostics-backend~           | Diagnostics backend (auto/flycheck/flymake) | ~'auto~                                |
+| ~claude-code-ide-prevent-reflow-glitch~         | Prevent terminal reflow glitch (bug #1422)  | ~t~                                    |
 
 *** Side Window Configuration
 
@@ -231,19 +231,19 @@ Claude Code IDE includes intelligent flicker reduction for vterm terminals to pr
 
 This optimization detects rapid terminal redraw sequences (like when Claude expands text areas) and batches them for smoother rendering. The 5ms default delay provides optimal visual quality with imperceptible latency.
 
-**** Eat Terminal Initialization Delay
+**** Terminal Initialization Delay
 
-When using the =eat= terminal backend, Claude Code IDE includes a brief initialization delay to ensure proper terminal layout rendering:
+Claude Code IDE includes a brief initialization delay when launching terminals to ensure proper layout rendering:
 
 #+begin_src emacs-lisp
-;; Adjust the eat initialization delay (default is 0.1 seconds)
-(setq claude-code-ide-eat-initialization-delay 0.15)
+;; Adjust the terminal initialization delay (default is 0.1 seconds)
+(setq claude-code-ide-terminal-initialization-delay 0.15)
 
 ;; Or disable it entirely (may cause visual glitches)
-(setq claude-code-ide-eat-initialization-delay 0)
+(setq claude-code-ide-terminal-initialization-delay 0)
 #+end_src
 
-This delay prevents display artifacts such as misaligned prompts and incorrect cursor positioning that can occur when eat's terminal emulation is initializing. The default 100ms delay is imperceptible but ensures reliable terminal startup.
+This delay prevents display artifacts such as misaligned prompts and incorrect cursor positioning that can occur when terminal emulation is initializing. The default 100ms delay is imperceptible but ensures reliable terminal startup.
 
 **** Terminal Keybindings
 

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -652,21 +652,34 @@ have completed before cleanup.  Waits up to 5 seconds."
     (claude-code-ide-check-status)
     (should claude-code-ide--cli-available)))
 
-(ert-deftest claude-code-ide-test-eat-initialization-delay ()
-  "Test eat terminal initialization delay configuration."
+(ert-deftest claude-code-ide-test-terminal-initialization-delay ()
+  "Test terminal initialization delay configuration."
   ;; Test default value
-  (should (boundp 'claude-code-ide-eat-initialization-delay))
-  (should (numberp claude-code-ide-eat-initialization-delay))
-  (should (= claude-code-ide-eat-initialization-delay 0.1))
+  (should (boundp 'claude-code-ide-terminal-initialization-delay))
+  (should (numberp claude-code-ide-terminal-initialization-delay))
+  (should (= claude-code-ide-terminal-initialization-delay 0.1))
 
   ;; Test customization
-  (let ((original-delay claude-code-ide-eat-initialization-delay))
+  (let ((original-delay claude-code-ide-terminal-initialization-delay))
     (unwind-protect
         (progn
-          (setq claude-code-ide-eat-initialization-delay 0.2)
-          (should (= claude-code-ide-eat-initialization-delay 0.2)))
+          (setq claude-code-ide-terminal-initialization-delay 0.2)
+          (should (= claude-code-ide-terminal-initialization-delay 0.2)))
       ;; Restore original value
-      (setq claude-code-ide-eat-initialization-delay original-delay))))
+      (setq claude-code-ide-terminal-initialization-delay original-delay))))
+
+(ert-deftest claude-code-ide-test-obsolete-eat-delay-alias ()
+  "Test that the obsolete eat delay alias still works."
+  ;; The alias should be defined
+  (should (boundp 'claude-code-ide-eat-initialization-delay))
+  ;; Setting the old variable should affect the new one
+  (let ((original-delay claude-code-ide-terminal-initialization-delay))
+    (unwind-protect
+        (progn
+          (setq claude-code-ide-eat-initialization-delay 0.3)
+          (should (= claude-code-ide-terminal-initialization-delay 0.3)))
+      ;; Restore original value
+      (setq claude-code-ide-terminal-initialization-delay original-delay))))
 
 (ert-deftest claude-code-ide-test-stop-no-session ()
   "Test stop command when no session is running."

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -229,18 +229,22 @@ with imperceptible latency."
   :type 'number
   :group 'claude-code-ide)
 
-(defcustom claude-code-ide-eat-initialization-delay 0.1
-  "Initialization delay for eat terminal stability.
-Provides a brief stabilization period when launching eat terminals
-to ensure proper layout calculation and rendering.  This parameter
-addresses timing requirements specific to eat's terminal emulation.
+(defcustom claude-code-ide-terminal-initialization-delay 0.1
+  "Initialization delay for terminal stability.
+Provides a brief stabilization period when launching terminals
+to ensure proper layout calculation and rendering.
 
-The delay allows eat to complete initial dimension calculations,
+The delay allows terminals to complete initial dimension calculations,
 preventing display artifacts like prompt misalignment and cursor
 positioning errors.  The 100ms default ensures reliable initialization
 without noticeable latency."
   :type 'number
   :group 'claude-code-ide)
+
+(define-obsolete-variable-alias
+  'claude-code-ide-eat-initialization-delay
+  'claude-code-ide-terminal-initialization-delay
+  "0.2.6")
 
 ;;; Constants
 
@@ -876,9 +880,8 @@ This function handles:
                    ((eq claude-code-ide-terminal-backend 'eat)
                     ;; eat uses kill-buffer-on-exit variable
                     (setq-local eat-kill-buffer-on-exit t))))
-                ;; Stabilization period for eat terminal layout initialization
-                (when (eq claude-code-ide-terminal-backend 'eat)
-                  (sleep-for claude-code-ide-eat-initialization-delay))
+                ;; Stabilization period for terminal layout initialization
+                (sleep-for claude-code-ide-terminal-initialization-delay)
                 ;; Display the buffer in a side window
                 (claude-code-ide--display-buffer-in-side-window buffer)
                 (claude-code-ide-log "Claude Code %sstarted in %s with MCP on port %d%s"


### PR DESCRIPTION
- Rename claude-code-ide-eat-initialization-delay to claude-code-ide-terminal-initialization-delay
- Remove backend-specific checks, apply delay unconditionally
- Add obsolete variable alias for backward compatibility
- Update tests to verify both new variable and obsolete alias
- Update documentation to reflect generalized behavior

This makes the initialization delay more general and future-proof, applying to any terminal backend to prevent display artifacts during terminal startup.