### PR TITLE
Fix newline binding to use correct M-RET vs S-RET

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -437,12 +437,12 @@ This function binds:
   (cond
    ((eq claude-code-ide-terminal-backend 'vterm)
     ;; For vterm, we set up local keybindings in vterm-mode-map
-    (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
+    (local-set-key (kbd "M-<return>") #'claude-code-ide-insert-newline)
     (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
    ((eq claude-code-ide-terminal-backend 'eat)
     ;; For eat, we need to modify the semi-char mode map which is the default
     ;; We use local-set-key to make it buffer-local
-    (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
+    (local-set-key (kbd "M-<return>") #'claude-code-ide-insert-newline)
     (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
    (t
     (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))


### PR DESCRIPTION
Looks like the newline binding was set to use the Super key instead of Meta for the newline insertion. Swapped it to the correct value which emulates the claude code terminal behavior. 

*Feel free to disregard if Super was the intended key sequence.*