### PR TITLE
Add configuration to control tab-bar switching on ediff

### DIFF
--- a/README.org
+++ b/README.org
@@ -164,6 +164,7 @@ You can run multiple Claude Code instances simultaneously for different projects
 | ~claude-code-ide-focus-claude-after-ediff~      | Focus Claude window after opening ediff     | ~t~                                    |
 | ~claude-code-ide-show-claude-window-in-ediff~   | Show Claude window during ediff             | ~t~                                    |
 | ~claude-code-ide-use-ide-diff~                  | Use IDE diff viewer instead of terminal     | ~t~                                    |
+| ~claude-code-ide-switch-tab-on-ediff~           | Switch to Claude's tab when opening ediff   | ~t~                                    |
 | ~claude-code-ide-system-prompt~                 | Custom system prompt to append              | ~nil~                                  |
 | ~claude-code-ide-enable-mcp-server~             | Enable MCP tools server                     | ~nil~                                  |
 | ~claude-code-ide-mcp-server-port~               | Port for MCP tools server                   | ~nil~ (auto-select)                    |

--- a/claude-code-ide-mcp-handlers.el
+++ b/claude-code-ide-mcp-handlers.el
@@ -489,19 +489,21 @@ ARGUMENTS should contain:
         ;; Clean up existing diff
         (claude-code-ide-mcp--cleanup-diff tab-name session)))
 
-    ;; Switch to original tab if we're on a different one
-    (when-let ((original-tab (claude-code-ide-mcp-session-original-tab session)))
-      (when (and (fboundp 'tab-bar-mode)
-                 tab-bar-mode
-                 (fboundp 'tab-bar--current-tab)
-                 (fboundp 'tab-bar-select-tab-by-name))
-        (let ((current-tab (tab-bar--current-tab)))
-          ;; Compare tab names or indices
-          (when (and original-tab current-tab
-                     (not (equal (alist-get 'name original-tab)
-                                 (alist-get 'name current-tab))))
-            ;; Switch to the original tab
-            (tab-bar-select-tab-by-name (alist-get 'name original-tab))))))
+    ;; Switch to original tab if we're on a different one (when configured)
+    (when (and claude-code-ide-switch-tab-on-ediff
+               (claude-code-ide-mcp-session-original-tab session))
+      (let ((original-tab (claude-code-ide-mcp-session-original-tab session)))
+        (when (and (fboundp 'tab-bar-mode)
+                   tab-bar-mode
+                   (fboundp 'tab-bar--current-tab)
+                   (fboundp 'tab-bar-select-tab-by-name))
+          (let ((current-tab (tab-bar--current-tab)))
+            ;; Compare tab names or indices
+            (when (and original-tab current-tab
+                       (not (equal (alist-get 'name original-tab)
+                                   (alist-get 'name current-tab))))
+              ;; Switch to the original tab
+              (tab-bar-select-tab-by-name (alist-get 'name original-tab)))))))
 
     ;; Save current window configuration
     (let* ((saved-winconf (current-window-configuration))

--- a/claude-code-ide-transient.el
+++ b/claude-code-ide-transient.el
@@ -63,6 +63,7 @@
 (defvar claude-code-ide-focus-claude-after-ediff)
 (defvar claude-code-ide-show-claude-window-in-ediff)
 (defvar claude-code-ide-use-ide-diff)
+(defvar claude-code-ide-switch-tab-on-ediff)
 (defvar claude-code-ide-use-side-window)
 (defvar claude-code-ide-cli-debug)
 (defvar claude-code-ide-cli-extra-flags)
@@ -280,6 +281,12 @@ Otherwise, if multiple sessions exist, prompt for selection."
   (setq claude-code-ide-use-ide-diff (not claude-code-ide-use-ide-diff))
   (claude-code-ide-log "IDE diff viewer %s" (if claude-code-ide-use-ide-diff "enabled" "disabled")))
 
+(transient-define-suffix claude-code-ide--toggle-switch-tab-on-ediff ()
+  "Toggle tab switching on ediff setting."
+  (interactive)
+  (setq claude-code-ide-switch-tab-on-ediff (not claude-code-ide-switch-tab-on-ediff))
+  (claude-code-ide-log "Switch tab on ediff %s" (if claude-code-ide-switch-tab-on-ediff "enabled" "disabled")))
+
 (transient-define-suffix claude-code-ide--toggle-cli-debug ()
   "Toggle CLI debug mode."
   (interactive)
@@ -296,6 +303,7 @@ Otherwise, if multiple sessions exist, prompt for selection."
   (customize-save-variable 'claude-code-ide-focus-claude-after-ediff claude-code-ide-focus-claude-after-ediff)
   (customize-save-variable 'claude-code-ide-show-claude-window-in-ediff claude-code-ide-show-claude-window-in-ediff)
   (customize-save-variable 'claude-code-ide-use-ide-diff claude-code-ide-use-ide-diff)
+  (customize-save-variable 'claude-code-ide-switch-tab-on-ediff claude-code-ide-switch-tab-on-ediff)
   (customize-save-variable 'claude-code-ide-use-side-window claude-code-ide-use-side-window)
   (customize-save-variable 'claude-code-ide-cli-path claude-code-ide-cli-path)
   (customize-save-variable 'claude-code-ide-cli-extra-flags claude-code-ide-cli-extra-flags)
@@ -346,6 +354,9 @@ Otherwise, if multiple sessions exist, prompt for selection."
     ("i" "Toggle IDE diff viewer" claude-code-ide--toggle-use-ide-diff
      :description (lambda () (format "IDE diff viewer (%s)"
                                      (if claude-code-ide-use-ide-diff "ON" "OFF"))))
+    ("t" "Toggle tab switching on ediff" claude-code-ide--toggle-switch-tab-on-ediff
+     :description (lambda () (format "Tab switch on ediff (%s)"
+                                     (if claude-code-ide-switch-tab-on-ediff "ON" "OFF"))))
     ("u" "Toggle side window" claude-code-ide--toggle-use-side-window
      :description (lambda () (format "Use side window (%s)"
                                      (if claude-code-ide-use-side-window "ON" "OFF"))))]

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -188,6 +188,14 @@ display diffs in the terminal instead."
   :type 'boolean
   :group 'claude-code-ide)
 
+(defcustom claude-code-ide-switch-tab-on-ediff t
+  "Whether to switch back to Claude's original tab when opening ediff.
+When non-nil (default), Claude Code will switch back to the tab
+where Claude Code was started when opening an ediff session.
+When nil, the current tab remains active when ediff is opened."
+  :type 'boolean
+  :group 'claude-code-ide)
+
 (defcustom claude-code-ide-use-side-window t
   "Whether to display Claude Code in a side window.
 When non-nil (default), Claude Code opens in a dedicated side window


### PR DESCRIPTION
Add new `claude-code-ide-switch-tab-on-ediff` configuration option that allows users to control whether Claude automatically switches back to its original tab when opening an ediff session. Defaults to t to maintain existing behavior.