### PR TITLE
Fix off-by-one error in line numbers for at-mentioned selections

### DIFF
--- a/claude-code-ide-mcp.el
+++ b/claude-code-ide-mcp.el
@@ -908,8 +908,8 @@ This should be called when the buffer's context might have changed."
   ;; Only send if there's an actual region selected
   (when (use-region-p)
     (let* ((file-path (or (buffer-file-name) ""))
-           (start-line (line-number-at-pos (region-beginning)))
-           (end-line (line-number-at-pos (region-end))))
+           (start-line (1- (line-number-at-pos (region-beginning))))
+           (end-line (1- (line-number-at-pos (region-end)))))
       (claude-code-ide-mcp--send-notification
        "at_mentioned"
        `((filePath . ,file-path)


### PR DESCRIPTION
Convert from 1-based to 0-based line numbering when sending selected text to Claude Code.