### PR TITLE
Add window toggle to claude-code-ide-switch-to-buffer

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -1024,9 +1024,7 @@ If the buffer is already visible, switch focus to it."
     (if-let ((buffer (get-buffer buffer-name)))
         (if (equal (buffer-name) buffer-name)
             ;; Already in Claude Code buffer, switch to MRU window
-            (if-let ((prev-window (get-mru-window nil nil t)))
-                (select-window prev-window)
-              (user-error "No other windows available to switch to"))
+            (select-window (get-mru-window nil nil t))
           ;; Not in Claude Code buffer, switch to it
           (if-let ((window (get-buffer-window buffer)))
               ;; Buffer is visible, just focus it


### PR DESCRIPTION
## Summary

Add toggle behavior to `claude-code-ide-switch-to-buffer`: when already in the Claude Code buffer, switch back to the most recently used window.

## Implementation

Modified `claude-code-ide-switch-to-buffer` to:
- Detect when already in Claude Code buffer and toggle back to previous window
- Use Emacs built-in `get-mru-window` API for MRU window tracking

## Test Plan

- [x] All existing tests pass