### PR TITLE
fix: add missing apropos require for xref-find-apropos

### DIFF
--- a/claude-code-ide-emacs-tools.el
+++ b/claude-code-ide-emacs-tools.el
@@ -34,6 +34,7 @@
 (require 'project)
 (require 'cl-lib)
 (require 'imenu)
+(require 'apropos)
 
 ;; Tree-sitter declarations
 (declare-function treesit-node-at "treesit" (pos &optional parser-or-lang named))


### PR DESCRIPTION
The `claude-code-ide-mcp-xref-find-apropos` function uses `xref-backend-apropos`, which internally calls `apropos-parse-pattern` from the `apropos` library. However, `apropos` is not autoloaded by default in Emacs - it only loads when explicitly invoked via commands like `M-x apropos`.

Without this require, calling the MCP tool fails with:
  "Symbol's function definition is void: apropos-parse-pattern"

This fix ensures the apropos library is loaded when the emacs-tools module is loaded, making xref-find-apropos work reliably.