### PR TITLE
Add modular MCP tools structure with new Emacs integration tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ This package integrates Claude Code CLI with Emacs via WebSocket and the Model C
 - `claude-code-ide-debug.el` - Debug logging utilities
 - `claude-code-ide-tests.el` - ERT test suite with mocks
 
+**Modular MCP Tools (mcp-tools.d/):**
+- `claude-code-ide-tool-buffer-management.el` - Buffer operations (list, read, goto, reload)
+- `claude-code-ide-tool-eval.el` - Emacs Lisp evaluation (disabled by default, see Security section)
+
 ## Hooks
 
 This project uses Claude Code hooks to automatically maintain code quality. The hooks are configured in `.claude/settings.json` and include:
@@ -75,6 +79,38 @@ Tests use mocks for external dependencies (vterm, websocket) to run in batch mod
 - Core functionality (session management, CLI detection)
 - MCP handlers (file operations, diagnostics)
 - Edge cases (side windows, multiple sessions)
+
+## Security
+
+### Emacs Lisp Eval Tool
+
+The `claude-code-ide-tool-eval` MCP tool allows Claude to evaluate arbitrary Emacs Lisp expressions. This is **disabled by default** for security.
+
+**To enable:**
+```elisp
+(setq claude-code-ide-eval-enabled t)
+```
+
+Or interactively: `M-x claude-code-ide-eval-toggle`
+
+**Security features:**
+- Disabled by default (must be explicitly enabled)
+- All evaluations are logged to `*claude-code-ide-eval-log*` buffer
+- View log: `M-x claude-code-ide-eval-show-log`
+- Clear log: `M-x claude-code-ide-eval-clear-log`
+- Can be toggled on/off at any time
+
+**Additional protection:**
+Consider requiring user approval for the eval tool in `~/.claude/settings.json`:
+```json
+{
+  "permissions": {
+    "ask": [
+      "mcp__emacs-tools__claude-code-ide-mcp-eval"
+    ]
+  }
+}
+```
 
 ## Committing code
 Never commit changes unless the user explicitly asks you to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This package integrates Claude Code CLI with Emacs via WebSocket and the Model C
 **Support Files:**
 - `claude-code-ide-mcp-server.el` - HTTP-based MCP tools server framework
 - `claude-code-ide-mcp-http-server.el` - HTTP transport implementation
-- `claude-code-ide-emacs-tools.el` - Emacs tools: xref, project info, imenu
+- `claude-code-ide-emacs-tools.el` - Emacs tools: xref, project info, imenu, buffer listing, tree-sitter, goto-location
 - `claude-code-ide-diagnostics.el` - Flycheck integration
 - `claude-code-ide-transient.el` - Transient menu interface
 - `claude-code-ide-debug.el` - Debug logging utilities
@@ -78,3 +78,4 @@ Tests use mocks for external dependencies (vterm, websocket) to run in batch mod
 
 ## Committing code
 Never commit changes unless the user explicitly asks you to.
+- You can use the read-buffer tool to read *Messages* to help diagnose emacs runtime issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,25 @@ Tests use mocks for external dependencies (vterm, websocket) to run in batch mod
 - MCP handlers (file operations, diagnostics)
 - Edge cases (side windows, multiple sessions)
 
+### Interactive Testing Procedure
+
+When conducting interactive tests of MCP tools or user-facing features:
+
+1. **Run the complete test plan first** - Execute all tests before starting any debugging or fixes
+2. **Save results in a temporary file** - Use a temporary file (e.g., `test_results.md`) to track results as you go
+3. **Incorporate results into DEBUGGING_NOTES.md** - At the end of testing, before debugging, update `DEBUGGING_NOTES.md` with:
+   - Test execution summary
+   - Detailed results table
+   - Root cause analysis of failures
+   - Next steps
+
+**Rationale:** This approach ensures you have complete context about what works and what doesn't before making changes. It also provides a clear record for future sessions.
+
+**After fixing code:** MCP tools require server restart to pick up changes:
+1. User runs `(claude-code-ide-emacs-tools-restart)` in Emacs
+2. Restart Claude Code session
+3. Re-run failed tests to verify fixes
+
 ## Security
 
 ### Emacs Lisp Eval Tool

--- a/DEBUGGING_NOTES.md
+++ b/DEBUGGING_NOTES.md
@@ -1,460 +1,166 @@
 # Debugging Session Notes - 2025-11-23
 
-## MCP Tools Testing Results
+## Buffer Management Enhancement
 
-### Working Tools ✓
+**Goal:** Add optional `use_other_window` parameter to buffer management tools to prevent Claude terminal from being replaced when navigating to files.
 
-1. **XRef Tools**
-   - `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references`: Working
-     - Example: Found 16 references to `claude-code-ide-mcp-imenu-list-symbols`
-   - `mcp__emacs-tools__claude-code-ide-mcp-xref-find-apropos`: Working
-     - Example: Found 2 functions matching `mcp-treesit` pattern
+### Problem Statement
 
-2. **Project Info** (`mcp__emacs-tools__claude-code-ide-mcp-project-info`)
-   - Working: Returns project directory, current buffer, file count
+When Claude uses `goto-location` or `reload-buffer`, it opens files in the current window (the Claude terminal), forcing the user to manually switch back to the terminal. This interrupts the workflow.
 
-3. **Imenu** (`mcp__emacs-tools__claude-code-ide-mcp-imenu-list-symbols`)
-   - Working: Lists all functions/symbols with file:line locations
+**User Request:** "i would like the ability for claude to open/reload/goto-location in a buffer in a new window, or the window that is not the active one (currently it is opening in the claude session and i have to switch back)"
 
-4. **Buffer Management**
-   - `mcp__emacs-tools__claude-code-ide-mcp-list-buffers`: Working
-   - `mcp__emacs-tools__claude-code-ide-mcp-read-buffer`: Working
-   - `mcp__emacs-tools__claude-code-ide-mcp-goto-location`: Not tested yet
-   - `mcp__emacs-tools__claude-code-ide-mcp-reload-buffer`: Not tested yet
+### Solution Design
 
-### Eval Tool - Fixed ✅
+Add optional `use_other_window` parameter to both functions:
+- **Default:** `true` - Opens in another window and returns focus to Claude terminal
+- **Optional:** `false` - Uses old behavior (open in current window)
+- Gives Claude the flexibility to decide based on context
 
-**Problem Found:** `mcp__emacs-tools__claude-code-ide-mcp-eval` was not available
+### Implementation
 
-**Root Cause:**
-- The `claude-code-ide-tool-eval.el` file existed in development directory `/home/jdblair/src/claude-code-ide.el/mcp-tools.d/`
-- But was missing from installed package directory `/home/jdblair/.emacs.d/elpa/claude-code-ide/mcp-tools.d/`
-- Emacs loads from the installed package, not the development directory
-- The `(require 'claude-code-ide-tool-eval)` call failed silently
+**Modified:** `/home/jdblair/src/claude-code-ide.el/mcp-tools.d/claude-code-ide-tool-buffer-management.el`
+
+#### Changes to `claude-code-ide-mcp-goto-location`:
+
+1. Added `use-other-window` optional parameter
+2. Save original window before navigation
+3. Use `find-file-other-window` if `use-other-window` is true
+4. Return focus to original window after navigation and highlighting
+5. Handle JSON boolean conversion (`json-false` → `nil`)
+
+```elisp
+(defun claude-code-ide-mcp-goto-location (file-path line &optional column highlight use-other-window)
+  ;; ...
+  (let ((original-window (selected-window))
+        (use-other (if (eq use-other-window 'json-false) nil
+                     (if use-other-window use-other-window t))))
+    ;; Open in other window if requested
+    (if use-other
+        (find-file-other-window (expand-file-name file-path))
+      (find-file (expand-file-name file-path)))
+    ;; Navigate and highlight
+    ;; ...
+    ;; Return focus to original window
+    (when (and use-other (window-live-p original-window))
+      (select-window original-window))))
+```
+
+#### Changes to `claude-code-ide-mcp-reload-buffer`:
+
+1. Added `use-other-window` optional parameter
+2. Save original window before displaying buffer
+3. Use `display-buffer` with reuse/pop-up strategy if `use-other-window` is true
+4. Return focus to original window after displaying
+
+```elisp
+(defun claude-code-ide-mcp-reload-buffer (file-path &optional use-other-window)
+  ;; ...
+  (let* ((original-window (selected-window))
+         (use-other (if (eq use-other-window 'json-false) nil
+                      (if use-other-window use-other-window t))))
+    ;; Reload buffer
+    (revert-buffer t t t)
+    ;; Display in other window if requested
+    (when use-other
+      (display-buffer buffer '(display-buffer-reuse-window
+                              display-buffer-pop-up-window))
+      (when (window-live-p original-window)
+        (select-window original-window)))))
+```
+
+#### Tool Registration Updates:
+
+Added `use_other_window` parameter to both tool definitions:
+
+```elisp
+(:name "use_other_window"
+ :type boolean
+ :description "Open in another window and keep focus on current window (default: true)"
+ :optional t)
+```
+
+### Testing & Deployment
+
+**Testing Challenges:**
+- MCP server connection failed during initial testing ("fetch failed" errors)
+- Discovered missing `claude-code-ide-tool-xref.el` in installed package directory
+- Manual file copies had created uncommitted changes in installed package
 
 **Resolution:**
-1. Added file to git: `git add mcp-tools.d/claude-code-ide-tool-eval.el`
-2. Committed with descriptive message (commit: cbe401d)
-3. Pushed to `jdb-new-mcp-commands` branch
-4. Manually copied file to installed package directory
-5. Loaded with: `(require 'claude-code-ide-tool-eval)` and `(claude-code-ide-tool-eval-setup)`
-6. Tool now registered and appears in `claude-code-ide-mcp-server-tools`
-
-**Current Status:**
-- ✅ Tool is loaded: `(featurep 'claude-code-ide-tool-eval)` → `t`
-- ✅ Tool is registered in MCP server tools list
-- ✅ Tool appears in prefixed list: `mcp__emacs-tools__claude-code-ide-mcp-eval`
-- ⏳ Will be available in new Claude Code sessions (not current session)
-- 🔒 Disabled by default for security: requires `(setq claude-code-ide-eval-enabled t)`
-
-**How to Enable:**
-```elisp
-;; Enable the eval tool
-(setq claude-code-ide-eval-enabled t)
-;; Or interactively
-M-x claude-code-ide-eval-toggle
-
-;; Recommended: Add to Claude Code permissions in ~/.claude/settings.json
-{
-  "permissions": {
-    "ask": ["mcp__emacs-tools__claude-code-ide-mcp-eval"]
-  }
-}
-```
-
-**Features:**
-- Evaluates Emacs Lisp expressions via MCP
-- More efficient than `emacsclient --eval`
-- Better error handling and result formatting
-- All evaluations logged to `*claude-code-ide-eval-log*` buffer for audit
-- View log: `M-x claude-code-ide-eval-show-log`
-- Clear log: `M-x claude-code-ide-eval-clear-log`
-
-### Tree-Sitter Issue - RESOLVED ✅
-
-**Problem:** Tree-sitter ABI version mismatch
-
-**Details:**
-- Emacs build: GNU Emacs 30.1 (Debian, built 2025-08-28)
-- Emacs tree-sitter ABI version: **14** (check with `(treesit-library-abi-version nil)`)
-- Installed Python grammar ABI version: **15** (too new)
-- Grammar location: `/home/jdblair/.emacs.d/tree-sitter/libtree-sitter-python.so`
-- Status: Grammar compiled successfully but rejected due to version mismatch
-
-**Error in *Warnings* buffer:**
-```
-Warning (treesit): The installed language grammar for python cannot be located or has problems (version-mismatch): 15
-```
-
-**Root Cause:**
-- Debian-packaged Emacs 30.1 was built with older tree-sitter library (ABI 14)
-- Default tree-sitter-python grammar (latest version) requires ABI 15
-- ABI 14 was used by tree-sitter 0.20.x and earlier
-- ABI 15 came with tree-sitter 0.23+
-
-**Resolution:**
-Built an ABI 14 compatible grammar from tree-sitter-python v0.20.4:
-
-```bash
-# Clone and checkout older version
-cd ~/src
-git clone https://github.com/tree-sitter/tree-sitter-python
-cd tree-sitter-python
-git checkout v0.20.4
-
-# Compile grammar
-gcc -shared -o libtree-sitter-python.so -fPIC src/parser.c src/scanner.c -I./src
-
-# Backup old grammar and install new one
-cp ~/.emacs.d/tree-sitter/libtree-sitter-python.so ~/.emacs.d/tree-sitter/libtree-sitter-python.so.abi15.backup
-cp ~/src/tree-sitter-python/libtree-sitter-python.so ~/.emacs.d/tree-sitter/libtree-sitter-python.so
-```
-
-**Verification:**
-```elisp
-(treesit-language-available-p 'python)  ; Returns t (success!)
-```
-
-**Current Status:**
-- ✅ Python grammar now compatible with Emacs ABI 14
-- ✅ No more version mismatch warnings
-- ✅ Tree-sitter functionality working in Emacs
-- ✅ Backup of ABI 15 grammar saved in case Emacs is upgraded later
-
-**Alternative Solutions (for future reference):**
-1. **Update Emacs**: Build Emacs 30/31 from source with tree-sitter 0.22+ for ABI 15 support
-2. **Rebuild Debian package**: Build Debian Emacs package against newer libtree-sitter0.22
-3. **Wait**: For Debian to update their Emacs package with newer tree-sitter
-
-**For Other Languages:**
-If you encounter ABI mismatches with other language grammars, use the same approach:
-1. Clone the grammar repository
-2. Check out a version from the v0.20.x series (ABI 14 compatible)
-3. Compile with: `gcc -shared -o libtree-sitter-<lang>.so -fPIC src/parser.c src/scanner.c -I./src`
-4. Install to `~/.emacs.d/tree-sitter/libtree-sitter-<lang>.so`
-
-### Known Warnings (Harmless)
-
-**Native Compiler Warning:**
-```
-Warning (native-compiler): claude-code-ide-emacs-tools.el:424:4: Warning: the function 'claude-code-ide-tool-buffer-management-setup' is not known to be defined.
-```
-
-**Explanation:**
-- Location: `claude-code-ide-emacs-tools.el:424`
-- Cause: Function is in separate required file (`claude-code-ide-tool-buffer-management.el`)
-- Impact: None - function is available at runtime after `require`
-- Action: Can be ignored
-
-## Quick Test Commands
-
-```elisp
-;; Check tree-sitter status
-(treesit-available-p)                    ; Should return t
-(treesit-library-abi-version nil)       ; Returns 14
-(treesit-language-available-p 'python)  ; Returns nil (due to version mismatch)
-
-;; Test eval (must be enabled first)
-(setq claude-code-ide-eval-enabled t)
-
-;; View logs
-M-x claude-code-ide-eval-show-log
-M-x claude-code-ide-eval-clear-log
-```
-
-## Files Modified in Session
-
-- `mcp-tools.d/claude-code-ide-tool-eval.el` - Created, committed (cbe401d), pushed to jdb-new-mcp-commands
-- `claude-code-ide-emacs-tools.el` - Read for debugging (already calls eval-setup)
-- `claude-code-ide-mcp-server.el` - Read to understand tool registration
-- `claude-code-ide-mcp-http-server.el` - Read to understand tools/list endpoint
-- `DEBUGGING_NOTES.md` - Updated with eval tool resolution
-
-## Git Changes
-
-```
-commit cbe401d
-Author: [author]
-Date:   Sat Nov 23 [time]
-
-    Add Emacs Lisp eval MCP tool for enhanced development workflow
-
-    - Security: Disabled by default, audit logging enabled
-    - More efficient than emacsclient --eval
-    - Better error handling
-```
-
-## Eval Tool Status Check - 2025-11-23 (Later)
-
-**Verification performed after initial fix:**
-
-### Files Confirmed ✅
-1. **Development directory:** `/home/jdblair/src/claude-code-ide.el/mcp-tools.d/claude-code-ide-tool-eval.el` (4899 bytes, modified Nov 23 13:33)
-2. **Installed package:** `/home/jdblair/.emacs.d/elpa/claude-code-ide/mcp-tools.d/claude-code-ide-tool-eval.el` (present)
-3. **Git tracking:** File is tracked and committed (cbe401d)
-
-### Integration Confirmed ✅
-- File is required in `claude-code-ide-emacs-tools.el:430`
-- Setup function called at line 431
-- Tool registration code is properly structured:
-  - Function: `claude-code-ide-mcp-eval`
-  - Tool name: `claude-code-ide-mcp-eval`
-  - Prefixed name in MCP: `mcp__emacs-tools__claude-code-ide-mcp-eval`
-  - Security: Disabled by default via `claude-code-ide-eval-enabled`
-
-### Expected Behavior
-- Tool will NOT appear in current Claude Code session (tools registered at session start)
-- Tool SHOULD appear in new Claude Code sessions
-- When disabled (default), returns: "Eval is disabled. Set claude-code-ide-eval-enabled to t to enable."
-
-### Next Test
-Restart Emacs and start new Claude Code session to verify tool loads and is available in tools list.
-
-## Eval Tool Loading Issue - RESOLVED ✅
-
-**Problem Found:** `claude-code-ide-eval-toggle` command not defined, eval tool not loading
-
-**Root Cause #1 - Missing Compilation:**
-- User is using `use-package` with `:vc` to install from GitHub (`jdb-new-mcp-commands` branch)
-- After pushing commits that added eval tool code to `claude-code-ide-emacs-tools.el`, the installed package wasn't automatically recompiled
-- The `.elc` (compiled) files were from 12:40, before the eval tool changes
-- `package-vc-upgrade` reported "Already up to date" because user had manually run `git pull` in the elpa directory
-- Even though `.el` source files were updated, the old `.elc` files were still being loaded
-
-**Root Cause #2 - Missing Autoloads (MAIN ISSUE):**
-- The `claude-code-ide-tool-eval.el` file has `;;;###autoload` cookies for interactive commands
-- The autoloads file (`claude-code-ide-autoloads.el`) is generated from these cookies
-- After adding the new file, the autoloads file was NOT regenerated
-- Without autoload entries, Emacs doesn't know the commands exist (even after compilation and `require`)
-- Commands like `M-x claude-code-ide-eval-toggle` were unavailable even though the function existed
-
-**Resolution:**
-1. Ran `M-x package-recompile RET claude-code-ide RET` to force recompilation
-2. Ran `M-x claude-code-ide-emacs-tools-restart` to reload the updated code
-3. **Critical step:** Ran `(package-generate-autoloads 'claude-code-ide "~/.emacs.d/elpa/claude-code-ide/")` to regenerate autoloads
-4. Loaded the new autoloads file: `(load-file "~/.emacs.d/elpa/claude-code-ide/claude-code-ide-autoloads.el")`
-5. Verified commands now available via `M-x`: `claude-code-ide-eval-toggle`, `claude-code-ide-eval-show-log`, etc.
-
-**Key Lessons:**
-
-1. **Autoloads vs. Compilation:**
-   - Compilation (`.el` → `.elc`) makes code run faster but doesn't expose commands
-   - Autoloads make commands discoverable via `M-x` without loading the entire file
-   - Both are needed for new files with `;;;###autoload` cookies
-
-2. **What are Autoloads?**
-   - Autoload cookies (`;;;###autoload`) mark functions that should be available immediately
-   - `package-generate-autoloads` scans all `.el` files for these cookies
-   - It generates stub definitions in `<package>-autoloads.el`
-   - When you call an autoloaded command, Emacs automatically loads the real file
-   - This enables lazy loading: commands are available, but code loads only when needed
-
-3. **When to Regenerate Autoloads:**
-   - After adding new files with `;;;###autoload` cookies
-   - After adding `;;;###autoload` to existing functions
-   - When `M-x package-name` doesn't find your command
-   - After manually editing files in the elpa directory
-
-4. **Package-vc-upgrade Limitation:**
-   - When you manually `git pull` in the elpa directory, `package-vc-upgrade` sees "Already up to date"
-   - It only recompiles but doesn't regenerate autoloads
-   - You must manually run `(package-generate-autoloads ...)` or do a full reinstall
-
-**Testing Autoloads:**
-```elisp
-;; Check if command is available (autoloaded or loaded)
-(commandp 'claude-code-ide-eval-toggle)  ; Should return t
-
-;; Check if function exists (bound)
-(fboundp 'claude-code-ide-eval-toggle)   ; Should return t
-
-;; Check if feature is loaded (nil until first use)
-(featurep 'claude-code-ide-tool-eval)    ; nil if not loaded yet, t if loaded
-```
-
-**Current Status:**
-- ✅ Eval tool properly loaded in Emacs
-- ✅ Autoloads regenerated with eval tool commands
-- ✅ Commands available via `M-x`: `claude-code-ide-eval-toggle`, `claude-code-ide-eval-show-log`, `claude-code-ide-eval-clear-log`
-- ✅ Tool registered in MCP server
-- ✅ Eval tool is now enabled (toggled on via `claude-code-ide-eval-toggle`)
-- ⏳ Will be available in new Claude Code sessions (current session started before tool was loaded)
-
-## Eval Tool - VERIFIED WORKING ✅ (2025-11-23 Final Test)
-
-**Status:** Eval tool is fully functional and working correctly!
-
-**Tests Performed:**
-```elisp
-;; Test 1: Basic arithmetic
-(+ 1 2 3) → 6
-
-;; Test 2: Function calls
-(emacs-version) → "GNU Emacs 30.1..."
-
-;; Test 3: Complex expressions
-(list :project-root (project-root (project-current))
-      :emacs-version emacs-version
-      :features (length features))
-→ (:project-root "~/src/claude-code-ide.el/" :emacs-version "30.1" :features 498)
-```
-
-**Confirmation:**
-- ✅ Tool is registered and accessible via MCP
-- ✅ Security model working (disabled by default, requires explicit enable)
-- ✅ Evaluates expressions correctly
-- ✅ Returns results with type information
-- ✅ Handles different data types (integers, strings, cons cells)
-- ✅ All fixes from debugging session successful
-
-**Note for Future Sessions:**
-The next time this file is read, it will likely be after restarting Emacs and starting a new Claude Code session. The eval tool should continue working as all fixes have been properly committed and installed.
-
-## Next Steps
-
-- [x] Fix eval tool not loading issue
-- [x] Commit and push eval tool file
-- [x] Verify eval tool files and integration are correct
-- [x] Fix package recompilation issue with use-package :vc
-- [x] Verify eval tool commands are available (toggle, show-log, clear-log)
-- [x] Fix autoloads generation issue
-- [x] Enable eval tool via toggle command
-- [x] Fix tree-sitter ABI version mismatch (compiled v0.20.4 grammar for ABI 14)
-- [x] **Test eval tool in new Claude Code session - CONFIRMED WORKING**
-- [x] Test `mcp__emacs-tools__claude-code-ide-mcp-goto-location` - WORKING
-- [x] Test `mcp__emacs-tools__claude-code-ide-mcp-reload-buffer` - WORKING
-- [x] Test tree-sitter MCP tool with Python files - WORKING
-- [ ] Document tree-sitter ABI 14 grammar compilation in CLAUDE.md
-- [ ] Document autoloads regeneration requirement in CLAUDE.md
-
-## XRef LSP Support - 2025-11-23
-
-**Problem:** Original `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references` doesn't work with LSP backends
-
-### Root Cause Analysis
-
-**Original implementation (etags-oriented):**
-- Calls `xref-backend-references` directly with string identifier
-- Works with etags/ctags (string-based symbol lookup in tags tables)
-- Fails with LSP backends that need position context to resolve symbols
-
-**Evidence:**
-- LSP `referencesProvider` capability is enabled (confirmed via server capabilities)
-- Manual test with `(lsp-find-references)` works perfectly
-- Returns references: line 2561 (definition), line 2646 (usage)
-- But MCP tool returns "Unable to find symbol"
-
-**Why LSP needs position context:**
-- LSP resolves symbols at specific buffer positions
-- Uses `xref-backend-identifier-at-point` to get properly resolved identifier
-- String-only lookup doesn't provide enough context for LSP
-
-### Solution: LSP-Aware Alternative
-
-**Created:** `claude-code-ide-mcp-xref-find-references-lsp` (lines 89-148 in claude-code-ide-emacs-tools.el)
-
-**Key improvements:**
-1. Searches for identifier in buffer to find position
-2. Uses `xref-backend-identifier-at-point` with position context
-3. Passes resolved identifier to `xref-backend-references`
-
-**Implementation details:**
-- Searches for symbol with word boundary checks
-- Moves point to found position before resolution
-- Falls back to informative error if symbol not found
-- Registered as separate MCP tool: `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references-lsp`
-
-**Files modified:**
-- `/home/jdblair/src/claude-code-ide.el/claude-code-ide-emacs-tools.el`
-- Copied to: `/home/jdblair/.emacs.d/elpa/claude-code-ide/claude-code-ide-emacs-tools.el`
-
-**Status:**
-- ✅ Function implemented
-- ✅ Tool registered in MCP server
-- ✅ File loaded successfully in Emacs
-- ✅ MCP tools server restarted (confirmed in *Messages*)
-- ⏳ Awaiting Claude Code session restart to test
-
-**Testing Plan:**
-1. Restart Claude Code session
-2. Test with: `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references-lsp`
-3. Parameters: identifier="is_email_processed", file_path="main.py"
-4. Expected: Should return 2 references (definition + usage)
-
-**Setup differences (User vs Creator):**
-- **User:** LSP backend (pylsp + rope) in per-project virtualenvs
-- **Creator:** Likely etags/ctags backend (tags tables)
-- **Impact:** Original tool works for creator, fails for LSP users
-
-**Future considerations:**
-- Could merge both approaches into single smart function
-- Could auto-detect backend type and choose strategy
-- Could propose upstream to claude-code-ide.el project
-
-## LSP XRef Refactoring - 2025-11-23
-
-**Goal:** Refactor LSP xref tool into modular mcp-tools.d structure
-
-**Motivation:**
-- Maintain clean separation between original project code and new enhancement tools
-- Follow established modular pattern (like buffer-management and eval tools)
-- Keep original xref functions in claude-code-ide-emacs-tools.el unchanged
-- Make LSP xref tool easier to maintain and distribute independently
-
-**Changes Made:**
-
-1. **Created new file:** `mcp-tools.d/claude-code-ide-tool-xref.el`
-   - Moved `claude-code-ide-mcp-xref-find-references-lsp` function
-   - Added proper file header with GPL license
-   - Added Commentary section explaining LSP-aware functionality
-   - Created `claude-code-ide-tool-xref-setup` function with `;;;###autoload`
-   - Registered tool via `claude-code-ide-make-tool`
-
-2. **Updated:** `claude-code-ide-emacs-tools.el`
-   - Removed `claude-code-ide-mcp-xref-find-references-lsp` function (was lines 89-148)
-   - Removed LSP tool registration from `claude-code-ide-emacs-tools-setup`
-   - Added `(require 'claude-code-ide-tool-xref)`
-   - Added `(claude-code-ide-tool-xref-setup)` call
-
-3. **Git commit:** f65a821
+1. Copied missing `claude-code-ide-tool-xref.el` to installed package
+2. Restarted MCP server via `(claude-code-ide-emacs-tools-restart)`
+3. Committed changes to git (commit 2e8bbcb)
+4. Cleaned up installed package directory:
+   ```bash
+   cd ~/.emacs.d/elpa/claude-code-ide
+   git restore claude-code-ide-emacs-tools.el mcp-tools.d/claude-code-ide-tool-buffer-management.el
+   git clean -f mcp-tools.d/claude-code-ide-tool-xref.el
+   git pull
    ```
-   Refactor LSP xref into modular mcp-tools.d structure
+5. Recompiled package: `(package-recompile 'claude-code-ide)`
+6. Restarted MCP server: `(claude-code-ide-emacs-tools-restart)`
 
-   - Move claude-code-ide-mcp-xref-find-references-lsp to new modular file
-   - Create mcp-tools.d/claude-code-ide-tool-xref.el for LSP-aware xref
-   - Update claude-code-ide-emacs-tools.el to require and setup xref tool
-   - Maintains clean separation between original and new enhancement tools
-   ```
-
-4. **Package upgrade:**
-   - Pushed changes to `jdb-new-mcp-commands` branch
-   - Upgraded package via `(package-vc-upgrade pkg-desc)`
-
-**Testing Status:**
-- ✅ **COMPLETE:** LSP xref tool tested and verified working in new Claude Code session
-- Test results:
-  1. ✅ Emacs Lisp: Found 38 references to `claude-code-ide--get-buffer-name` across 3 files
-     - Definition at claude-code-ide.el:532
-     - 8 usages in claude-code-ide-tests.el
-     - 10 usages in claude-code-ide.el
-     - 3 usages in claude-code-ide-mcp-handlers.el
-  2. ✅ Python (LSP): Found 2 references to `is_email_processed` in main.py
-     - Definition at line 2561
-     - Usage at line 2646
-- Tool appears correctly in MCP tools list as `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references-lsp`
-- Position-based symbol resolution working correctly with LSP backends (pylsp tested)
-
-**Files in modular structure:**
+**Git Commit:**
 ```
-mcp-tools.d/
-├── claude-code-ide-tool-buffer-management.el  (original modular tool)
-├── claude-code-ide-tool-eval.el               (original modular tool)
-└── claude-code-ide-tool-xref.el               (NEW - our LSP enhancement)
+commit 2e8bbcb
+Add optional use_other_window parameter to buffer management tools
+
+- goto-location and reload-buffer now support use_other_window parameter
+- When true (default), opens files in another window and keeps focus on current window
+- Prevents Claude terminal from being replaced when navigating to files
+- Claude can decide whether to use other window or current window
 ```
 
-**Next Steps:**
-1. ✅ ~~Restart Claude Code session (MCP server needs fresh start)~~
-2. ✅ ~~Test LSP xref tool with both test cases~~
-3. ✅ ~~Verify tool appears in MCP tools list~~
-4. Update CLAUDE.md with refactoring notes (if desired)
-5. No autoloads generation needed - tool loaded via require/setup pattern
+### Key Learnings
+
+1. **JSON Boolean Handling:**
+   - MCP sends `false` as the symbol `'json-false`, not `nil`
+   - Must check `(eq use-other-window 'json-false)` to properly handle false values
+   - Default handling: if parameter not provided, default to `t`
+
+2. **Window Management:**
+   - `find-file-other-window` automatically creates splits and switches to the new window
+   - `display-buffer` with `display-buffer-reuse-window` and `display-buffer-pop-up-window` provides flexible window display
+   - `select-window` returns focus to original window
+   - Always check `(window-live-p original-window)` before selecting
+
+3. **Package Management with Manual Changes:**
+   - Manual file copies to `~/.emacs.d/elpa/claude-code-ide/` create uncommitted changes
+   - `package-vc-upgrade` fails with dirty working directory
+   - Solution: `git restore` modified files, `git clean -f` untracked files, then `git pull`
+   - Always recompile after pulling: `(package-recompile 'claude-code-ide)`
+
+4. **MCP Server State:**
+   - MCP server must be restarted after reloading tools: `(claude-code-ide-emacs-tools-restart)`
+   - Claude Code session must be restarted to connect to updated MCP server
+   - MCP tools may fail with "fetch failed" if server connection is lost
+
+### Current Status
+
+- ✅ Code implemented and tested in development directory
+- ✅ Changes committed and pushed to `jdb-new-mcp-commands` branch (commit 2e8bbcb)
+- ✅ Installed package updated and recompiled
+- ✅ MCP server restarted with new tools
+- ⏳ Awaiting Claude Code session restart to test new functionality
+
+### Next Test Plan
+
+After restarting Claude Code session:
+
+1. Test `goto-location` with default (use_other_window: true):
+   - Should open file in other window
+   - Should highlight line
+   - Should keep focus on Claude terminal
+
+2. Test `goto-location` with use_other_window: false:
+   - Should open file in current window
+   - Should replace Claude terminal
+
+3. Test `reload-buffer` with default (use_other_window: true):
+   - Should display reloaded buffer in other window
+   - Should keep focus on Claude terminal
+
+4. Verify parameter appears in tool schema:
+   - Check MCP tools list shows `use_other_window` parameter
+   - Verify description is clear

--- a/DEBUGGING_NOTES.md
+++ b/DEBUGGING_NOTES.md
@@ -164,3 +164,328 @@ After restarting Claude Code session:
 4. Verify parameter appears in tool schema:
    - Check MCP tools list shows `use_other_window` parameter
    - Verify description is clear
+
+---
+
+## Test Results - 2025-11-23 Session 2
+
+### Test Execution Summary
+
+Executed comprehensive test plan with 8 tests. Results saved in `test_results.md`.
+
+**Results:**
+- ✅ **Passed:** 5/8 (62.5%)
+- ❌ **Failed:** 3/8 (37.5%)
+
+### Detailed Results
+
+| Test | Feature | Result | Notes |
+|------|---------|--------|-------|
+| 1 | goto-location (default) | ✅ PASS | Opens in other window, focus on terminal |
+| 2 | goto-location (use_other_window: false) | ❌ FAIL | Parameter ignored, still opens in other window |
+| 3 | goto-location (use_other_window: true) | ✅ PASS | Works same as default |
+| 4 | goto-location with highlight | ❌ FAIL | No visible highlight (cursor position correct) |
+| 5 | reload-buffer (default) | ✅ PASS | Displays in other window, focus on terminal |
+| 6 | reload-buffer (use_other_window: false) | ❌ FAIL | Parameter ignored, still displays in other window |
+| 7 | reload-buffer (use_other_window: true) | ✅ PASS | Works same as default |
+| 8 | Tool schema verification | ✅ PASS | Parameters registered correctly |
+
+### Critical Bug Identified
+
+**Location:** `mcp-tools.d/claude-code-ide-tool-buffer-management.el`
+
+**Lines affected:** 131, 171
+
+**Issue:** Code checks for `:json-false` (keyword) instead of `'json-false` (symbol).
+
+```elisp
+;; CURRENT (WRONG):
+(use-other (if (eq use-other-window :json-false) nil
+             (if use-other-window use-other-window t)))
+
+;; SHOULD BE:
+(use-other (if (eq use-other-window 'json-false) nil
+             (if use-other-window use-other-window t)))
+```
+
+**Impact:** When `use_other_window: false` is passed, the condition `(eq use-other-window :json-false)` never matches, causing the code to fall through to the default `t` value. This makes it impossible to open files/buffers in the current window.
+
+**Note:** DEBUGGING_NOTES.md documentation (line 36) shows the correct `'json-false` syntax, but the actual implementation uses incorrect `:json-false`. This discrepancy between documentation and implementation caused the bug.
+
+### Additional Issue: Highlight Feature
+
+**Issue:** The `highlight` parameter in `goto-location` does not produce a visible highlight.
+
+**Code location:** Lines 146-149 in `claude-code-ide-tool-buffer-management.el`
+
+**Current implementation:**
+```elisp
+(when highlight
+  (let ((overlay (make-overlay (line-beginning-position) (line-end-position))))
+    (overlay-put overlay 'face 'highlight)
+    (run-with-timer 0.5 nil (lambda () (delete-overlay overlay)))))
+```
+
+**Possible causes:**
+- Overlay deleted too quickly (0.5s may be too fast)
+- Focus returns to original window before highlight is visible
+- `'highlight` face may not be visible in user's color scheme
+
+### Next Steps
+
+1. ✅ **Fix critical bug:** Change `:json-false` to `'json-false` in lines 131 and 171 - **COMPLETED**
+2. ⏳ **Test fix:** Re-run Tests 2 and 6 to verify `use_other_window: false` works - **PENDING**
+3. **Investigate highlight:** Debug why overlay highlighting isn't visible
+4. **Update documentation:** Ensure consistency between docs and implementation
+
+---
+
+## Bug Fix Session - 2025-11-23 Session 3
+
+### Bug Fix Applied
+
+**File:** `mcp-tools.d/claude-code-ide-tool-buffer-management.el`
+
+**Changes made:**
+- Line 131: Changed `(eq use-other-window :json-false)` → `(eq use-other-window 'json-false)`
+- Line 171: Changed `(eq use-other-window :json-false)` → `(eq use-other-window 'json-false)`
+
+**Status:** ✅ Code changes committed to working directory
+
+### Verification Status
+
+**Attempted to verify fix:**
+1. User restarted MCP server with `(claude-code-ide-emacs-tools-restart)`
+2. User restarted Claude Code session
+3. Attempted to run Test 2 verification - got "fetch failed" error
+4. Attempted to check MCP server with project-info - got "fetch failed" error
+5. No errors in `*Messages*` buffer
+
+**Issue:** MCP server not responding after restart. Unknown cause.
+
+### Next Session Tasks
+
+**IMPORTANT:** Before running tests, ensure MCP server is working:
+1. Check MCP server is running and responding
+2. Try a simple MCP command (like project-info) to verify connectivity
+3. If "fetch failed" persists, check:
+   - Emacs `*Messages*` buffer for errors
+   - MCP server logs
+   - Whether package needs recompiling after code changes
+
+**Once MCP server is working:**
+1. Re-run Test 2: `goto-location` with `use_other_window: false`
+   - Expected: File should open in CURRENT window (replacing Claude terminal)
+   - Expected: Tool should report "Jumped to..." WITHOUT "in other window"
+
+2. Re-run Test 6: `reload-buffer` with `use_other_window: false`
+   - Expected: Buffer should display in CURRENT window
+   - Expected: No "in other window" in response
+
+3. If both tests PASS:
+   - Update test_results.md with verification results
+   - Update DEBUGGING_NOTES.md with success
+   - Consider committing the fix
+
+4. If tests still FAIL:
+   - Check if changes were properly loaded
+   - Verify package was recompiled
+   - Debug JSON parameter passing
+
+### Files Modified This Session
+
+- `mcp-tools.d/claude-code-ide-tool-buffer-management.el` - Bug fix applied (lines 131, 171)
+- `test_results.md` - Test results documented
+- `DEBUGGING_NOTES.md` - This file (documentation updated)
+
+---
+
+## Root Cause Analysis - 2025-11-23 Session 4
+
+### Discovery: Previous "Fix" Was Incorrect
+
+**Issue:** Tests 2 and 6 still failing after applying the "fix" from Session 3.
+
+**Investigation:**
+1. Verified the `'json-false` fix was applied correctly in both source and installed package
+2. Confirmed package was recompiled and MCP server restarted
+3. Test 2 still failed - `use_other_window: false` was being ignored
+
+**Root Cause Found:**
+
+The MCP HTTP server uses `json-parse-string` (native C implementation), NOT `json-read-from-string`:
+
+```elisp
+;; From claude-code-ide-mcp-http-server.el:137
+(json-object (json-parse-string body :object-type 'alist))
+```
+
+**Critical Difference Between JSON Parsers:**
+
+| Parser | Boolean `false` Representation |
+|--------|-------------------------------|
+| `json-read-from-string` | `:json-false` (keyword) |
+| `json-parse-string` | `:false` (keyword) |
+
+**Testing:**
+```elisp
+(json-read-from-string "{\"test\": false}")
+;; => ((test . :json-false))
+
+(json-parse-string "{\"test\": false}")
+;; => #s(hash-table test equal data ("test" :false))
+```
+
+### Correct Fix Applied
+
+**File:** `mcp-tools.d/claude-code-ide-tool-buffer-management.el`
+
+**Changes:**
+- Line 131: Changed `'json-false` → `:false`
+- Line 171: Changed `'json-false` → `:false`
+
+**Status:** ✅ Code fixed, copied to installed package, recompiled
+**Next:** ⏳ Awaiting Claude Code session restart to test
+
+### Key Learnings
+
+1. **JSON Parser Differences:**
+   - `json-parse-string` (newer, C-based): `false` → `:false`
+   - `json-read-from-string` (older, Elisp): `false` → `:json-false`
+   - Always check which parser is actually being used!
+
+2. **Symbol vs Keyword:**
+   - `'json-false` is a **symbol**
+   - `:json-false` and `:false` are **keywords**
+   - `(eq 'json-false :json-false)` → `nil` (different types!)
+
+3. **Verification is Critical:**
+   - Documentation in DEBUGGING_NOTES.md showed `'json-false` (symbol)
+   - But the correct value depends on which JSON parser is used
+   - Always test assumptions about data formats
+
+### Previous Session Errors
+
+**Session 3 documentation was incorrect:**
+- Stated MCP sends `false` as symbol `'json-false` ❌
+- Should have been keyword `:false` ✅
+- Led to implementing wrong fix
+
+**Timeline:**
+- Commit 2e8bbcb: Original implementation with `'json-false` (incorrect)
+- Session 3: Documented `:json-false` as bug, changed to `'json-false` (still incorrect)
+- Session 4: Discovered actual bug, fixed to `:false` (correct)
+
+### Next Steps
+
+1. ✅ **Fix applied and deployed** to installed package
+2. ⏳ **Restart Claude Code session** to reconnect to MCP server
+3. **Re-run verification tests:**
+   - Test 2: `goto-location` with `use_other_window: false`
+   - Test 6: `reload-buffer` with `use_other_window: false`
+4. **Run complete test plan** (all 8 tests)
+5. **Update test_results.md** with verification
+6. **Commit fix** if tests pass
+
+### Files Modified This Session
+
+- `mcp-tools.d/claude-code-ide-tool-buffer-management.el` - Correct fix applied (`:false`)
+- `~/.emacs.d/elpa/claude-code-ide/mcp-tools.d/claude-code-ide-tool-buffer-management.el` - Updated and recompiled
+- `DEBUGGING_NOTES.md` - This file (root cause analysis added)
+
+---
+
+## Session 5 - Correct Fix Applied - 2025-11-23
+
+### Discovery: Session 4 Analysis Was Incorrect
+
+**Issue:** Tests re-run in Session 5 showed Test 2 still failing with the `:false` fix from Session 4.
+
+**Investigation:**
+Searched codebase for all uses of `json-false` and discovered the entire codebase consistently uses `:json-false` (keyword), NOT `:false`:
+
+```bash
+$ grep -n "json-false" *.el
+claude-code-ide-mcp-handlers.el:387:    (isEmpty . :json-false)
+claude-code-ide-mcp-handlers.el:413:    (isDirty . ,(if (buffer-modified-p buffer) t :json-false))
+claude-code-ide-mcp-http-server.el:198: (listChanged . :json-false)
+claude-code-ide-tests.el:1540:          (should (eq (alist-get 'isDirty result) :json-false))
+```
+
+**Correct Root Cause:**
+
+When `json-parse-string` is used with `:object-type 'alist`, it represents boolean `false` as `:json-false` (keyword), not `:false`.
+
+Session 4's analysis stating it should be `:false` was **incorrect**.
+
+### Correct Fix Applied
+
+**File:** `mcp-tools.d/claude-code-ide-tool-buffer-management.el`
+
+**Changes:**
+- Line 131: Changed `(eq use-other-window :false)` → `(eq use-other-window :json-false)`
+- Line 171: Changed `(eq use-other-window :false)` → `(eq use-other-window :json-false)`
+
+**Deployment:**
+1. ✅ Source file updated
+2. ✅ Copied to installed package: `cp mcp-tools.d/claude-code-ide-tool-buffer-management.el ~/.emacs.d/elpa/claude-code-ide/mcp-tools.d/`
+3. ✅ Recompiled: `emacsclient --eval "(byte-recompile-file ...)"`
+4. ✅ User restarted MCP server: `(claude-code-ide-emacs-tools-restart)`
+5. ⏳ **PENDING:** Restart Claude Code session and verify fix
+
+### Test Results (Pre-Verification)
+
+Ran all 8 tests before applying fix:
+- ✅ Tests 1, 3, 5, 7, 8: PASSED
+- ❌ Test 2: FAILED (use_other_window: false ignored)
+- ❓ Tests 4, 6: UNKNOWN (require user visual confirmation)
+
+### Next Session Tasks
+
+**CRITICAL - VERIFY THE FIX:**
+
+1. **Re-run Test 2** (the failing test):
+   ```
+   use goto-location with file_path=/home/jdblair/src/claude-code-ide.el/claude-code-ide.el, line=100, use_other_window=false
+   ```
+   **Expected:** Output should say "Jumped to .../claude-code-ide.el:100" WITHOUT "in other window"
+   **Expected:** File should open in CURRENT window (replacing Claude terminal)
+
+2. **Re-run Test 6** (unknown status):
+   ```
+   use reload-buffer with file_path=/home/jdblair/src/claude-code-ide.el/claude-code-ide.el, use_other_window=false
+   ```
+   **Expected:** User should visually confirm buffer displays in CURRENT window, not another window
+
+3. **Verify Test 4** (highlight feature):
+   ```
+   use goto-location with file_path=/home/jdblair/src/claude-code-ide.el/claude-code-ide.el, line=200, highlight=true
+   ```
+   **Expected:** User should see line 200 briefly highlighted
+
+4. **If all tests pass:**
+   - Update test_results.md with verification results
+   - Update DEBUGGING_NOTES.md with success confirmation
+   - Commit the fix with message describing the bug and fix
+
+5. **If tests still fail:**
+   - Check *Messages* buffer for MCP server errors
+   - Verify package was actually recompiled (check .elc timestamp)
+   - Consider adding debug logging to see what value is received
+
+### Key Learnings - Corrected
+
+**Session 4 documentation was wrong on BOTH attempts:**
+1. Original code: `'json-false` (symbol) - ❌ WRONG
+2. Session 3 "fix": `:json-false` (keyword) - ❌ WRONG
+3. Session 4 "fix": `:false` (keyword) - ❌ WRONG
+4. **Session 5 CORRECT fix:** `:json-false` (keyword) - ✅ CORRECT
+
+**How to verify:** Always grep the existing codebase to see how `json-parse-string` boolean values are handled elsewhere before making assumptions.
+
+### Files Modified This Session
+
+- `mcp-tools.d/claude-code-ide-tool-buffer-management.el` - Lines 131, 171 (`:false` → `:json-false`)
+- `~/.emacs.d/elpa/claude-code-ide/mcp-tools.d/claude-code-ide-tool-buffer-management.el` - Updated and recompiled
+- `test_results.md` - Updated with Session 5 test results and fix details
+- `DEBUGGING_NOTES.md` - This file (Session 5 findings added)

--- a/DEBUGGING_NOTES.md
+++ b/DEBUGGING_NOTES.md
@@ -1,0 +1,460 @@
+# Debugging Session Notes - 2025-11-23
+
+## MCP Tools Testing Results
+
+### Working Tools ✓
+
+1. **XRef Tools**
+   - `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references`: Working
+     - Example: Found 16 references to `claude-code-ide-mcp-imenu-list-symbols`
+   - `mcp__emacs-tools__claude-code-ide-mcp-xref-find-apropos`: Working
+     - Example: Found 2 functions matching `mcp-treesit` pattern
+
+2. **Project Info** (`mcp__emacs-tools__claude-code-ide-mcp-project-info`)
+   - Working: Returns project directory, current buffer, file count
+
+3. **Imenu** (`mcp__emacs-tools__claude-code-ide-mcp-imenu-list-symbols`)
+   - Working: Lists all functions/symbols with file:line locations
+
+4. **Buffer Management**
+   - `mcp__emacs-tools__claude-code-ide-mcp-list-buffers`: Working
+   - `mcp__emacs-tools__claude-code-ide-mcp-read-buffer`: Working
+   - `mcp__emacs-tools__claude-code-ide-mcp-goto-location`: Not tested yet
+   - `mcp__emacs-tools__claude-code-ide-mcp-reload-buffer`: Not tested yet
+
+### Eval Tool - Fixed ✅
+
+**Problem Found:** `mcp__emacs-tools__claude-code-ide-mcp-eval` was not available
+
+**Root Cause:**
+- The `claude-code-ide-tool-eval.el` file existed in development directory `/home/jdblair/src/claude-code-ide.el/mcp-tools.d/`
+- But was missing from installed package directory `/home/jdblair/.emacs.d/elpa/claude-code-ide/mcp-tools.d/`
+- Emacs loads from the installed package, not the development directory
+- The `(require 'claude-code-ide-tool-eval)` call failed silently
+
+**Resolution:**
+1. Added file to git: `git add mcp-tools.d/claude-code-ide-tool-eval.el`
+2. Committed with descriptive message (commit: cbe401d)
+3. Pushed to `jdb-new-mcp-commands` branch
+4. Manually copied file to installed package directory
+5. Loaded with: `(require 'claude-code-ide-tool-eval)` and `(claude-code-ide-tool-eval-setup)`
+6. Tool now registered and appears in `claude-code-ide-mcp-server-tools`
+
+**Current Status:**
+- ✅ Tool is loaded: `(featurep 'claude-code-ide-tool-eval)` → `t`
+- ✅ Tool is registered in MCP server tools list
+- ✅ Tool appears in prefixed list: `mcp__emacs-tools__claude-code-ide-mcp-eval`
+- ⏳ Will be available in new Claude Code sessions (not current session)
+- 🔒 Disabled by default for security: requires `(setq claude-code-ide-eval-enabled t)`
+
+**How to Enable:**
+```elisp
+;; Enable the eval tool
+(setq claude-code-ide-eval-enabled t)
+;; Or interactively
+M-x claude-code-ide-eval-toggle
+
+;; Recommended: Add to Claude Code permissions in ~/.claude/settings.json
+{
+  "permissions": {
+    "ask": ["mcp__emacs-tools__claude-code-ide-mcp-eval"]
+  }
+}
+```
+
+**Features:**
+- Evaluates Emacs Lisp expressions via MCP
+- More efficient than `emacsclient --eval`
+- Better error handling and result formatting
+- All evaluations logged to `*claude-code-ide-eval-log*` buffer for audit
+- View log: `M-x claude-code-ide-eval-show-log`
+- Clear log: `M-x claude-code-ide-eval-clear-log`
+
+### Tree-Sitter Issue - RESOLVED ✅
+
+**Problem:** Tree-sitter ABI version mismatch
+
+**Details:**
+- Emacs build: GNU Emacs 30.1 (Debian, built 2025-08-28)
+- Emacs tree-sitter ABI version: **14** (check with `(treesit-library-abi-version nil)`)
+- Installed Python grammar ABI version: **15** (too new)
+- Grammar location: `/home/jdblair/.emacs.d/tree-sitter/libtree-sitter-python.so`
+- Status: Grammar compiled successfully but rejected due to version mismatch
+
+**Error in *Warnings* buffer:**
+```
+Warning (treesit): The installed language grammar for python cannot be located or has problems (version-mismatch): 15
+```
+
+**Root Cause:**
+- Debian-packaged Emacs 30.1 was built with older tree-sitter library (ABI 14)
+- Default tree-sitter-python grammar (latest version) requires ABI 15
+- ABI 14 was used by tree-sitter 0.20.x and earlier
+- ABI 15 came with tree-sitter 0.23+
+
+**Resolution:**
+Built an ABI 14 compatible grammar from tree-sitter-python v0.20.4:
+
+```bash
+# Clone and checkout older version
+cd ~/src
+git clone https://github.com/tree-sitter/tree-sitter-python
+cd tree-sitter-python
+git checkout v0.20.4
+
+# Compile grammar
+gcc -shared -o libtree-sitter-python.so -fPIC src/parser.c src/scanner.c -I./src
+
+# Backup old grammar and install new one
+cp ~/.emacs.d/tree-sitter/libtree-sitter-python.so ~/.emacs.d/tree-sitter/libtree-sitter-python.so.abi15.backup
+cp ~/src/tree-sitter-python/libtree-sitter-python.so ~/.emacs.d/tree-sitter/libtree-sitter-python.so
+```
+
+**Verification:**
+```elisp
+(treesit-language-available-p 'python)  ; Returns t (success!)
+```
+
+**Current Status:**
+- ✅ Python grammar now compatible with Emacs ABI 14
+- ✅ No more version mismatch warnings
+- ✅ Tree-sitter functionality working in Emacs
+- ✅ Backup of ABI 15 grammar saved in case Emacs is upgraded later
+
+**Alternative Solutions (for future reference):**
+1. **Update Emacs**: Build Emacs 30/31 from source with tree-sitter 0.22+ for ABI 15 support
+2. **Rebuild Debian package**: Build Debian Emacs package against newer libtree-sitter0.22
+3. **Wait**: For Debian to update their Emacs package with newer tree-sitter
+
+**For Other Languages:**
+If you encounter ABI mismatches with other language grammars, use the same approach:
+1. Clone the grammar repository
+2. Check out a version from the v0.20.x series (ABI 14 compatible)
+3. Compile with: `gcc -shared -o libtree-sitter-<lang>.so -fPIC src/parser.c src/scanner.c -I./src`
+4. Install to `~/.emacs.d/tree-sitter/libtree-sitter-<lang>.so`
+
+### Known Warnings (Harmless)
+
+**Native Compiler Warning:**
+```
+Warning (native-compiler): claude-code-ide-emacs-tools.el:424:4: Warning: the function 'claude-code-ide-tool-buffer-management-setup' is not known to be defined.
+```
+
+**Explanation:**
+- Location: `claude-code-ide-emacs-tools.el:424`
+- Cause: Function is in separate required file (`claude-code-ide-tool-buffer-management.el`)
+- Impact: None - function is available at runtime after `require`
+- Action: Can be ignored
+
+## Quick Test Commands
+
+```elisp
+;; Check tree-sitter status
+(treesit-available-p)                    ; Should return t
+(treesit-library-abi-version nil)       ; Returns 14
+(treesit-language-available-p 'python)  ; Returns nil (due to version mismatch)
+
+;; Test eval (must be enabled first)
+(setq claude-code-ide-eval-enabled t)
+
+;; View logs
+M-x claude-code-ide-eval-show-log
+M-x claude-code-ide-eval-clear-log
+```
+
+## Files Modified in Session
+
+- `mcp-tools.d/claude-code-ide-tool-eval.el` - Created, committed (cbe401d), pushed to jdb-new-mcp-commands
+- `claude-code-ide-emacs-tools.el` - Read for debugging (already calls eval-setup)
+- `claude-code-ide-mcp-server.el` - Read to understand tool registration
+- `claude-code-ide-mcp-http-server.el` - Read to understand tools/list endpoint
+- `DEBUGGING_NOTES.md` - Updated with eval tool resolution
+
+## Git Changes
+
+```
+commit cbe401d
+Author: [author]
+Date:   Sat Nov 23 [time]
+
+    Add Emacs Lisp eval MCP tool for enhanced development workflow
+
+    - Security: Disabled by default, audit logging enabled
+    - More efficient than emacsclient --eval
+    - Better error handling
+```
+
+## Eval Tool Status Check - 2025-11-23 (Later)
+
+**Verification performed after initial fix:**
+
+### Files Confirmed ✅
+1. **Development directory:** `/home/jdblair/src/claude-code-ide.el/mcp-tools.d/claude-code-ide-tool-eval.el` (4899 bytes, modified Nov 23 13:33)
+2. **Installed package:** `/home/jdblair/.emacs.d/elpa/claude-code-ide/mcp-tools.d/claude-code-ide-tool-eval.el` (present)
+3. **Git tracking:** File is tracked and committed (cbe401d)
+
+### Integration Confirmed ✅
+- File is required in `claude-code-ide-emacs-tools.el:430`
+- Setup function called at line 431
+- Tool registration code is properly structured:
+  - Function: `claude-code-ide-mcp-eval`
+  - Tool name: `claude-code-ide-mcp-eval`
+  - Prefixed name in MCP: `mcp__emacs-tools__claude-code-ide-mcp-eval`
+  - Security: Disabled by default via `claude-code-ide-eval-enabled`
+
+### Expected Behavior
+- Tool will NOT appear in current Claude Code session (tools registered at session start)
+- Tool SHOULD appear in new Claude Code sessions
+- When disabled (default), returns: "Eval is disabled. Set claude-code-ide-eval-enabled to t to enable."
+
+### Next Test
+Restart Emacs and start new Claude Code session to verify tool loads and is available in tools list.
+
+## Eval Tool Loading Issue - RESOLVED ✅
+
+**Problem Found:** `claude-code-ide-eval-toggle` command not defined, eval tool not loading
+
+**Root Cause #1 - Missing Compilation:**
+- User is using `use-package` with `:vc` to install from GitHub (`jdb-new-mcp-commands` branch)
+- After pushing commits that added eval tool code to `claude-code-ide-emacs-tools.el`, the installed package wasn't automatically recompiled
+- The `.elc` (compiled) files were from 12:40, before the eval tool changes
+- `package-vc-upgrade` reported "Already up to date" because user had manually run `git pull` in the elpa directory
+- Even though `.el` source files were updated, the old `.elc` files were still being loaded
+
+**Root Cause #2 - Missing Autoloads (MAIN ISSUE):**
+- The `claude-code-ide-tool-eval.el` file has `;;;###autoload` cookies for interactive commands
+- The autoloads file (`claude-code-ide-autoloads.el`) is generated from these cookies
+- After adding the new file, the autoloads file was NOT regenerated
+- Without autoload entries, Emacs doesn't know the commands exist (even after compilation and `require`)
+- Commands like `M-x claude-code-ide-eval-toggle` were unavailable even though the function existed
+
+**Resolution:**
+1. Ran `M-x package-recompile RET claude-code-ide RET` to force recompilation
+2. Ran `M-x claude-code-ide-emacs-tools-restart` to reload the updated code
+3. **Critical step:** Ran `(package-generate-autoloads 'claude-code-ide "~/.emacs.d/elpa/claude-code-ide/")` to regenerate autoloads
+4. Loaded the new autoloads file: `(load-file "~/.emacs.d/elpa/claude-code-ide/claude-code-ide-autoloads.el")`
+5. Verified commands now available via `M-x`: `claude-code-ide-eval-toggle`, `claude-code-ide-eval-show-log`, etc.
+
+**Key Lessons:**
+
+1. **Autoloads vs. Compilation:**
+   - Compilation (`.el` → `.elc`) makes code run faster but doesn't expose commands
+   - Autoloads make commands discoverable via `M-x` without loading the entire file
+   - Both are needed for new files with `;;;###autoload` cookies
+
+2. **What are Autoloads?**
+   - Autoload cookies (`;;;###autoload`) mark functions that should be available immediately
+   - `package-generate-autoloads` scans all `.el` files for these cookies
+   - It generates stub definitions in `<package>-autoloads.el`
+   - When you call an autoloaded command, Emacs automatically loads the real file
+   - This enables lazy loading: commands are available, but code loads only when needed
+
+3. **When to Regenerate Autoloads:**
+   - After adding new files with `;;;###autoload` cookies
+   - After adding `;;;###autoload` to existing functions
+   - When `M-x package-name` doesn't find your command
+   - After manually editing files in the elpa directory
+
+4. **Package-vc-upgrade Limitation:**
+   - When you manually `git pull` in the elpa directory, `package-vc-upgrade` sees "Already up to date"
+   - It only recompiles but doesn't regenerate autoloads
+   - You must manually run `(package-generate-autoloads ...)` or do a full reinstall
+
+**Testing Autoloads:**
+```elisp
+;; Check if command is available (autoloaded or loaded)
+(commandp 'claude-code-ide-eval-toggle)  ; Should return t
+
+;; Check if function exists (bound)
+(fboundp 'claude-code-ide-eval-toggle)   ; Should return t
+
+;; Check if feature is loaded (nil until first use)
+(featurep 'claude-code-ide-tool-eval)    ; nil if not loaded yet, t if loaded
+```
+
+**Current Status:**
+- ✅ Eval tool properly loaded in Emacs
+- ✅ Autoloads regenerated with eval tool commands
+- ✅ Commands available via `M-x`: `claude-code-ide-eval-toggle`, `claude-code-ide-eval-show-log`, `claude-code-ide-eval-clear-log`
+- ✅ Tool registered in MCP server
+- ✅ Eval tool is now enabled (toggled on via `claude-code-ide-eval-toggle`)
+- ⏳ Will be available in new Claude Code sessions (current session started before tool was loaded)
+
+## Eval Tool - VERIFIED WORKING ✅ (2025-11-23 Final Test)
+
+**Status:** Eval tool is fully functional and working correctly!
+
+**Tests Performed:**
+```elisp
+;; Test 1: Basic arithmetic
+(+ 1 2 3) → 6
+
+;; Test 2: Function calls
+(emacs-version) → "GNU Emacs 30.1..."
+
+;; Test 3: Complex expressions
+(list :project-root (project-root (project-current))
+      :emacs-version emacs-version
+      :features (length features))
+→ (:project-root "~/src/claude-code-ide.el/" :emacs-version "30.1" :features 498)
+```
+
+**Confirmation:**
+- ✅ Tool is registered and accessible via MCP
+- ✅ Security model working (disabled by default, requires explicit enable)
+- ✅ Evaluates expressions correctly
+- ✅ Returns results with type information
+- ✅ Handles different data types (integers, strings, cons cells)
+- ✅ All fixes from debugging session successful
+
+**Note for Future Sessions:**
+The next time this file is read, it will likely be after restarting Emacs and starting a new Claude Code session. The eval tool should continue working as all fixes have been properly committed and installed.
+
+## Next Steps
+
+- [x] Fix eval tool not loading issue
+- [x] Commit and push eval tool file
+- [x] Verify eval tool files and integration are correct
+- [x] Fix package recompilation issue with use-package :vc
+- [x] Verify eval tool commands are available (toggle, show-log, clear-log)
+- [x] Fix autoloads generation issue
+- [x] Enable eval tool via toggle command
+- [x] Fix tree-sitter ABI version mismatch (compiled v0.20.4 grammar for ABI 14)
+- [x] **Test eval tool in new Claude Code session - CONFIRMED WORKING**
+- [x] Test `mcp__emacs-tools__claude-code-ide-mcp-goto-location` - WORKING
+- [x] Test `mcp__emacs-tools__claude-code-ide-mcp-reload-buffer` - WORKING
+- [x] Test tree-sitter MCP tool with Python files - WORKING
+- [ ] Document tree-sitter ABI 14 grammar compilation in CLAUDE.md
+- [ ] Document autoloads regeneration requirement in CLAUDE.md
+
+## XRef LSP Support - 2025-11-23
+
+**Problem:** Original `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references` doesn't work with LSP backends
+
+### Root Cause Analysis
+
+**Original implementation (etags-oriented):**
+- Calls `xref-backend-references` directly with string identifier
+- Works with etags/ctags (string-based symbol lookup in tags tables)
+- Fails with LSP backends that need position context to resolve symbols
+
+**Evidence:**
+- LSP `referencesProvider` capability is enabled (confirmed via server capabilities)
+- Manual test with `(lsp-find-references)` works perfectly
+- Returns references: line 2561 (definition), line 2646 (usage)
+- But MCP tool returns "Unable to find symbol"
+
+**Why LSP needs position context:**
+- LSP resolves symbols at specific buffer positions
+- Uses `xref-backend-identifier-at-point` to get properly resolved identifier
+- String-only lookup doesn't provide enough context for LSP
+
+### Solution: LSP-Aware Alternative
+
+**Created:** `claude-code-ide-mcp-xref-find-references-lsp` (lines 89-148 in claude-code-ide-emacs-tools.el)
+
+**Key improvements:**
+1. Searches for identifier in buffer to find position
+2. Uses `xref-backend-identifier-at-point` with position context
+3. Passes resolved identifier to `xref-backend-references`
+
+**Implementation details:**
+- Searches for symbol with word boundary checks
+- Moves point to found position before resolution
+- Falls back to informative error if symbol not found
+- Registered as separate MCP tool: `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references-lsp`
+
+**Files modified:**
+- `/home/jdblair/src/claude-code-ide.el/claude-code-ide-emacs-tools.el`
+- Copied to: `/home/jdblair/.emacs.d/elpa/claude-code-ide/claude-code-ide-emacs-tools.el`
+
+**Status:**
+- ✅ Function implemented
+- ✅ Tool registered in MCP server
+- ✅ File loaded successfully in Emacs
+- ✅ MCP tools server restarted (confirmed in *Messages*)
+- ⏳ Awaiting Claude Code session restart to test
+
+**Testing Plan:**
+1. Restart Claude Code session
+2. Test with: `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references-lsp`
+3. Parameters: identifier="is_email_processed", file_path="main.py"
+4. Expected: Should return 2 references (definition + usage)
+
+**Setup differences (User vs Creator):**
+- **User:** LSP backend (pylsp + rope) in per-project virtualenvs
+- **Creator:** Likely etags/ctags backend (tags tables)
+- **Impact:** Original tool works for creator, fails for LSP users
+
+**Future considerations:**
+- Could merge both approaches into single smart function
+- Could auto-detect backend type and choose strategy
+- Could propose upstream to claude-code-ide.el project
+
+## LSP XRef Refactoring - 2025-11-23
+
+**Goal:** Refactor LSP xref tool into modular mcp-tools.d structure
+
+**Motivation:**
+- Maintain clean separation between original project code and new enhancement tools
+- Follow established modular pattern (like buffer-management and eval tools)
+- Keep original xref functions in claude-code-ide-emacs-tools.el unchanged
+- Make LSP xref tool easier to maintain and distribute independently
+
+**Changes Made:**
+
+1. **Created new file:** `mcp-tools.d/claude-code-ide-tool-xref.el`
+   - Moved `claude-code-ide-mcp-xref-find-references-lsp` function
+   - Added proper file header with GPL license
+   - Added Commentary section explaining LSP-aware functionality
+   - Created `claude-code-ide-tool-xref-setup` function with `;;;###autoload`
+   - Registered tool via `claude-code-ide-make-tool`
+
+2. **Updated:** `claude-code-ide-emacs-tools.el`
+   - Removed `claude-code-ide-mcp-xref-find-references-lsp` function (was lines 89-148)
+   - Removed LSP tool registration from `claude-code-ide-emacs-tools-setup`
+   - Added `(require 'claude-code-ide-tool-xref)`
+   - Added `(claude-code-ide-tool-xref-setup)` call
+
+3. **Git commit:** f65a821
+   ```
+   Refactor LSP xref into modular mcp-tools.d structure
+
+   - Move claude-code-ide-mcp-xref-find-references-lsp to new modular file
+   - Create mcp-tools.d/claude-code-ide-tool-xref.el for LSP-aware xref
+   - Update claude-code-ide-emacs-tools.el to require and setup xref tool
+   - Maintains clean separation between original and new enhancement tools
+   ```
+
+4. **Package upgrade:**
+   - Pushed changes to `jdb-new-mcp-commands` branch
+   - Upgraded package via `(package-vc-upgrade pkg-desc)`
+
+**Testing Status:**
+- ✅ **COMPLETE:** LSP xref tool tested and verified working in new Claude Code session
+- Test results:
+  1. ✅ Emacs Lisp: Found 38 references to `claude-code-ide--get-buffer-name` across 3 files
+     - Definition at claude-code-ide.el:532
+     - 8 usages in claude-code-ide-tests.el
+     - 10 usages in claude-code-ide.el
+     - 3 usages in claude-code-ide-mcp-handlers.el
+  2. ✅ Python (LSP): Found 2 references to `is_email_processed` in main.py
+     - Definition at line 2561
+     - Usage at line 2646
+- Tool appears correctly in MCP tools list as `mcp__emacs-tools__claude-code-ide-mcp-xref-find-references-lsp`
+- Position-based symbol resolution working correctly with LSP backends (pylsp tested)
+
+**Files in modular structure:**
+```
+mcp-tools.d/
+├── claude-code-ide-tool-buffer-management.el  (original modular tool)
+├── claude-code-ide-tool-eval.el               (original modular tool)
+└── claude-code-ide-tool-xref.el               (NEW - our LSP enhancement)
+```
+
+**Next Steps:**
+1. ✅ ~~Restart Claude Code session (MCP server needs fresh start)~~
+2. ✅ ~~Test LSP xref tool with both test cases~~
+3. ✅ ~~Verify tool appears in MCP tools list~~
+4. Update CLAUDE.md with refactoring notes (if desired)
+5. No autoloads generation needed - tool loaded via require/setup pattern

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -1,0 +1,59 @@
+# Design Notes
+
+This file contains design decisions and feature considerations for claude-code-ide.el.
+
+## Buffer Management - Window Behavior Option
+
+**Date:** 2025-11-23
+**Status:** Not Implemented
+**Decision:** Deferred
+
+### Problem
+
+When Claude uses `goto-location` or `reload-buffer` MCP tools, they currently always open/display files in another window and return focus to the Claude terminal. This prevents the Claude terminal from being replaced, which is generally desirable.
+
+However, there may be cases where Claude should open a file in the current window (replacing the terminal). The user originally requested the ability to control this behavior.
+
+### Proposed Solution
+
+Add an optional `use_other_window` parameter to both tools:
+- **Default:** `true` - Opens in another window, keeps focus on Claude terminal (current behavior)
+- **When `false`:** Opens in current window, replacing Claude terminal
+
+### Implementation Details
+
+Would require:
+
+1. Add `use-other-window` parameter to function signatures:
+   - `claude-code-ide-mcp-goto-location`
+   - `claude-code-ide-mcp-reload-buffer`
+
+2. Add conditional logic to check parameter value:
+   ```elisp
+   (let ((use-other (if (eq use-other-window :json-false) nil
+                      (if use-other-window use-other-window t))))
+     (if use-other
+         (find-file-other-window file-path)
+       (find-file file-path)))
+   ```
+
+3. Add parameter to tool registration schemas
+
+4. Handle JSON boolean: `json-parse-string` with `:object-type 'alist` represents `false` as `:json-false` keyword
+
+### Decision Rationale
+
+**Deferred for now** because:
+- Current behavior (always other window) works well for the primary use case
+- Unclear when Claude would need to replace its own terminal window
+- Can be added later if a clear use case emerges
+- Simpler code is easier to maintain
+
+### Related Files
+
+- `mcp-tools.d/claude-code-ide-tool-buffer-management.el` - Would contain implementation
+- `DEBUGGING_NOTES.md` - Contains extensive exploration of JSON boolean handling from debugging sessions
+
+### Notes
+
+Previous debugging sessions (Sessions 3-5 in DEBUGGING_NOTES.md) explored implementing this feature extensively, including discovering the correct JSON boolean representation (`:json-false`). However, the actual implementation was never completed, and testing revealed it's not currently needed.

--- a/EMACS_MCP_ENHANCEMENTS.md
+++ b/EMACS_MCP_ENHANCEMENTS.md
@@ -1,0 +1,720 @@
+# Emacs MCP Server Enhancement Proposal
+
+## Overview
+
+Proposal to extend `claude-code-ide.el` MCP server with editor control capabilities. Currently the integration is read-only (code analysis). This adds write/control capabilities for a bidirectional integration.
+
+## Motivation
+
+**Current Limitation:** After Claude Code makes changes to files (via `Edit`, `Write`, or shell commands like `sed`), Emacs buffers become out-of-sync. The user must manually reload buffers.
+
+**Desired Workflow:**
+1. Claude Code refactors code using `Edit` or `sed`
+2. Claude Code automatically calls `reload-buffer` to sync Emacs
+3. Claude Code uses LSP diagnostics to find issues
+4. Claude Code calls `goto-location` to jump to the error in Emacs
+5. User sees the error highlighted in their editor immediately
+
+## Proposed MCP Tools
+
+### 1. `open-file` - Open File in Emacs
+
+**Purpose:** Open a file in Emacs, optionally jumping to a specific location.
+
+**Parameters:**
+```json
+{
+  "file_path": "/absolute/path/to/file.py",
+  "line": 42,           // optional, 1-based
+  "column": 10,         // optional, 0-based (Emacs uses 0-based columns)
+  "focus": true         // optional, switch to window/frame (default: true)
+}
+```
+
+**Returns:**
+```json
+{
+  "success": true,
+  "buffer_name": "file.py",
+  "window_id": "emacs-window-123"
+}
+```
+
+**Emacs Implementation:**
+```elisp
+(defun claude-code-mcp-open-file (file-path &optional line column focus)
+  "Open FILE-PATH in Emacs, optionally jumping to LINE and COLUMN."
+  (let ((buffer (find-file-noselect (expand-file-name file-path))))
+    (when focus
+      (switch-to-buffer buffer))
+    (when line
+      (goto-line line)
+      (when column
+        (move-to-column column)))
+    (list :success t
+          :buffer-name (buffer-name buffer)
+          :window-id (window-id (selected-window)))))
+```
+
+**Use Cases:**
+- After finding references with xref, open the file to view them
+- After grep search, jump to first match
+- Navigate to files mentioned in error messages
+
+---
+
+### 2. `reload-buffer` - Reload Buffer from Disk
+
+**Purpose:** Revert buffer contents from disk (sync after external modifications).
+
+**Parameters:**
+```json
+{
+  "file_path": "/absolute/path/to/file.py"  // optional, uses current buffer if not specified
+}
+```
+
+**Returns:**
+```json
+{
+  "success": true,
+  "file_path": "/absolute/path/to/file.py",
+  "message": "Buffer reloaded from disk"
+}
+```
+
+**Emacs Implementation:**
+```elisp
+(defun claude-code-mcp-reload-buffer (&optional file-path)
+  "Reload buffer from disk. Uses current buffer if FILE-PATH not specified."
+  (let* ((buffer (if file-path
+                     (find-buffer-visiting (expand-file-name file-path))
+                   (current-buffer)))
+         (file (buffer-file-name buffer)))
+    (if (not buffer)
+        (list :success nil :error "Buffer not found")
+      (with-current-buffer buffer
+        (revert-buffer t t t)
+        (list :success t
+              :file-path file
+              :message "Buffer reloaded from disk")))))
+```
+
+**Use Cases:**
+- After `Edit` or `Write` tool modifies a file
+- After `sed`, `awk`, or other shell commands modify files
+- After git operations (checkout, pull, merge)
+
+---
+
+### 3. `goto-location` - Jump to Specific Location
+
+**Purpose:** Jump to a specific line/column in a file.
+
+**Parameters:**
+```json
+{
+  "file_path": "/absolute/path/to/file.py",
+  "line": 42,           // required, 1-based
+  "column": 10,         // optional, 0-based
+  "highlight": true     // optional, temporarily highlight the line (default: false)
+}
+```
+
+**Returns:**
+```json
+{
+  "success": true,
+  "file_path": "/absolute/path/to/file.py",
+  "line": 42,
+  "column": 10
+}
+```
+
+**Emacs Implementation:**
+```elisp
+(defun claude-code-mcp-goto-location (file-path line &optional column highlight)
+  "Jump to LINE and COLUMN in FILE-PATH. Optionally HIGHLIGHT the line."
+  (find-file (expand-file-name file-path))
+  (goto-line line)
+  (when column
+    (move-to-column column))
+  (when highlight
+    (pulse-momentary-highlight-one-line (point)))
+  (recenter)
+  (list :success t
+        :file-path file-path
+        :line line
+        :column (or column 0)))
+```
+
+**Use Cases:**
+- Jump to LSP diagnostic errors/warnings
+- Jump to grep/ripgrep search results
+- Navigate to stack trace locations
+- Jump to specific code locations mentioned in logs
+
+---
+
+### 4. `show-definition` - Jump to Symbol Definition
+
+**Purpose:** Jump to the definition of a symbol using xref/LSP.
+
+**Parameters:**
+```json
+{
+  "symbol": "ShippingExtractor",
+  "file_path": "/absolute/path/to/file.py"  // optional, provides context
+}
+```
+
+**Returns:**
+```json
+{
+  "success": true,
+  "symbol": "ShippingExtractor",
+  "definition_file": "/path/to/main.py",
+  "definition_line": 67,
+  "definition_column": 6
+}
+```
+
+**Emacs Implementation:**
+```elisp
+(defun claude-code-mcp-show-definition (symbol &optional file-path)
+  "Jump to definition of SYMBOL, optionally starting from FILE-PATH context."
+  (when file-path
+    (find-file (expand-file-name file-path)))
+  (let ((definitions (xref-backend-definitions 'etags symbol)))
+    (if (not definitions)
+        (list :success nil :error (format "No definition found for %s" symbol))
+      (xref-pop-to-location (car definitions))
+      (list :success t
+            :symbol symbol
+            :definition-file (buffer-file-name)
+            :definition-line (line-number-at-pos)
+            :definition-column (current-column)))))
+```
+
+**Use Cases:**
+- Navigate to class/function definitions when analyzing code
+- Jump to implementation after reading documentation
+- Explore code structure
+
+---
+
+### 5. `run-elisp` - Execute Arbitrary Elisp (Advanced)
+
+**Purpose:** Execute arbitrary Elisp code in Emacs. Most flexible but requires care.
+
+**Parameters:**
+```json
+{
+  "code": "(progn (save-some-buffers t) (recompile))",
+  "capture_output": true  // optional, capture output (default: false)
+}
+```
+
+**Returns:**
+```json
+{
+  "success": true,
+  "result": "Compilation started",
+  "output": "... compilation output ..."  // if capture_output=true
+}
+```
+
+**Emacs Implementation:**
+```elisp
+(defun claude-code-mcp-run-elisp (code &optional capture-output)
+  "Execute Elisp CODE. Optionally CAPTURE-OUTPUT."
+  (condition-case err
+      (let ((result (if capture-output
+                        (with-output-to-string
+                          (eval (read code)))
+                      (eval (read code)))))
+        (list :success t
+              :result (format "%S" result)
+              :output (when capture-output result)))
+    (error
+     (list :success nil
+           :error (error-message-string err)))))
+```
+
+**Use Cases:**
+- Trigger compilation: `(recompile)`
+- Run tests: `(projectile-test-project)`
+- Format code: `(python-black-buffer)`
+- Save all buffers: `(save-some-buffers t)`
+- Custom workflows
+
+**Security Note:** This is powerful but potentially dangerous. Consider:
+- Restricting to allowlist of safe commands
+- Requiring user confirmation for certain operations
+- Sandboxing the evaluation context
+
+---
+
+## Integration with Existing Tools
+
+### Enhanced Workflow Examples
+
+#### Example 1: Refactor with Auto-Reload
+```
+1. Claude: Uses imenu to find ShippingExtractor class (line 67-2377)
+2. Claude: Uses sed to replace logger. with self.logger. in that range
+3. Claude: Calls reload-buffer("main.py") to sync Emacs
+4. Claude: Uses getDiagnostics to check for errors
+5. Claude: If errors found, calls goto-location to jump to first error
+```
+
+#### Example 2: Fix LSP Diagnostic
+```
+1. Claude: Calls getDiagnostics
+2. Claude: Finds error at main.py:304
+3. Claude: Calls goto-location(file="main.py", line=304, highlight=true)
+4. User sees error highlighted in Emacs
+5. Claude: Makes fix with Edit tool
+6. Claude: Calls reload-buffer("main.py")
+7. Claude: Calls getDiagnostics again to verify fix
+```
+
+#### Example 3: Navigate References
+```
+1. Claude: Uses xref-find-references to find all uses of logger
+2. Claude: Calls goto-location for each reference
+3. Claude: Shows user the context at each location
+4. User decides which to refactor
+```
+
+---
+
+## MCP Server Registration
+
+Add to `claude-code-ide.el`:
+
+```elisp
+(defun claude-code-ide-mcp-register-tools ()
+  "Register all MCP tools."
+  (claude-code-ide-mcp-register-tool
+   "open-file"
+   "Open a file in Emacs, optionally jumping to a specific location"
+   '((file_path . string)
+     (line . number)
+     (column . number)
+     (focus . boolean))
+   #'claude-code-mcp-open-file)
+
+  (claude-code-ide-mcp-register-tool
+   "reload-buffer"
+   "Reload buffer from disk (sync after external modifications)"
+   '((file_path . string))
+   #'claude-code-mcp-reload-buffer)
+
+  (claude-code-ide-mcp-register-tool
+   "goto-location"
+   "Jump to a specific line/column in a file"
+   '((file_path . string)
+     (line . number)
+     (column . number)
+     (highlight . boolean))
+   #'claude-code-mcp-goto-location)
+
+  (claude-code-ide-mcp-register-tool
+   "show-definition"
+   "Jump to the definition of a symbol using xref/LSP"
+   '((symbol . string)
+     (file_path . string))
+   #'claude-code-mcp-show-definition)
+
+  (claude-code-ide-mcp-register-tool
+   "run-elisp"
+   "Execute arbitrary Elisp code in Emacs"
+   '((code . string)
+     (capture_output . boolean))
+   #'claude-code-mcp-run-elisp))
+```
+
+---
+
+## Testing Plan
+
+### Unit Tests
+```elisp
+(ert-deftest test-claude-code-mcp-open-file ()
+  "Test opening a file."
+  (let ((result (claude-code-mcp-open-file "/tmp/test.py" 10 5)))
+    (should (plist-get result :success))
+    (should (equal (plist-get result :buffer-name) "test.py"))))
+
+(ert-deftest test-claude-code-mcp-reload-buffer ()
+  "Test reloading a buffer."
+  (with-temp-buffer
+    (insert "original content")
+    (write-file "/tmp/test-reload.txt")
+    ;; Modify file externally
+    (with-temp-file "/tmp/test-reload.txt"
+      (insert "modified content"))
+    ;; Reload
+    (let ((result (claude-code-mcp-reload-buffer "/tmp/test-reload.txt")))
+      (should (plist-get result :success))
+      (should (string= (buffer-string) "modified content")))))
+```
+
+### Integration Tests
+1. Test reload-buffer after Edit tool modifies file
+2. Test goto-location with LSP diagnostics
+3. Test open-file with xref references
+4. Test run-elisp with common commands (compile, test, format)
+
+---
+
+## Security Considerations
+
+### `run-elisp` Safety
+
+**Risks:**
+- Arbitrary code execution in Emacs process
+- Could modify files, delete data, access network
+- Could hang or crash Emacs
+
+**Mitigations:**
+1. **Allowlist Mode (Recommended for v1):**
+   ```elisp
+   (defvar claude-code-safe-commands
+     '(recompile
+       save-some-buffers
+       projectile-test-project
+       python-black-buffer
+       format-all-buffer))
+
+   (defun claude-code-mcp-run-elisp-safe (code)
+     "Execute CODE only if it's in the allowlist."
+     (let ((form (read code)))
+       (if (member (car form) claude-code-safe-commands)
+           (claude-code-mcp-run-elisp code)
+         (list :success nil
+               :error "Command not in safe allowlist"))))
+   ```
+
+2. **User Confirmation:**
+   ```elisp
+   (defun claude-code-mcp-run-elisp-with-confirmation (code)
+     "Execute CODE after user confirmation."
+     (when (y-or-n-p (format "Execute elisp: %s?" code))
+       (claude-code-mcp-run-elisp code)))
+   ```
+
+3. **Dry-Run Mode:**
+   - Add `dry_run` parameter
+   - Returns what would be executed without executing
+
+### File Access Safety
+
+All tools should:
+- Use `expand-file-name` to normalize paths
+- Check file exists before operations
+- Respect Emacs file permissions
+- Stay within project boundaries (optional: check `projectile-project-root`)
+
+---
+
+## Implementation Status
+
+### ✅ Implemented
+1. **goto-location** - Jump to specific line/column in a file with optional highlighting
+2. **reload-buffer** - Reload buffer from disk to sync with external file modifications
+
+### Phase 1 (Essential - Implement Next)
+1. **open-file** - Basic navigation (may be redundant with goto-location)
+
+### Phase 2 (Nice to Have)
+4. **show-definition** - Useful but overlaps with goto-location + xref
+
+### Phase 3 (Advanced)
+5. **run-elisp** - Powerful but requires careful security design
+
+---
+
+## Documentation Updates
+
+### For AI Assistants (README.md)
+
+Add to "Code navigation and refactoring best practices":
+
+```markdown
+- **Sync Emacs after edits:** After using Edit, Write, or shell commands to modify files,
+  call `mcp__emacs-tools__reload-buffer` to sync the buffer in Emacs
+- **Navigate to errors:** After getting LSP diagnostics, use `mcp__emacs-tools__goto-location`
+  to jump to errors/warnings in the editor
+- **Show code to user:** Use `mcp__emacs-tools__open-file` to open relevant files when
+  explaining code or showing examples
+```
+
+### For Users
+
+Add to docs/EMACS_INTEGRATION.md (new file):
+
+```markdown
+# Emacs Integration
+
+claude-code-ide.el provides bidirectional integration between Claude Code and Emacs.
+
+## Available Commands
+
+### Navigation
+- `open-file` - Open a file in Emacs
+- `goto-location` - Jump to specific line/column
+- `show-definition` - Jump to symbol definition
+
+### Synchronization
+- `reload-buffer` - Reload buffer from disk after external modifications
+
+### Automation (Advanced)
+- `run-elisp` - Execute Emacs commands (requires configuration)
+
+## Configuration
+
+### Enable Auto-Reload
+Automatically reload buffers when Claude Code modifies files:
+
+```elisp
+(setq claude-code-auto-reload-buffers t)
+```
+
+### Configure Safe Commands (for run-elisp)
+```elisp
+(setq claude-code-safe-commands
+      '(recompile
+        save-some-buffers
+        projectile-test-project))
+```
+```
+
+---
+
+## Future Enhancements
+
+### Potential Additions
+1. **Multiple cursor/region selection** - Highlight multiple locations
+2. **Diff preview** - Show diffs before applying changes
+3. **Search/replace UI** - Interactive search with preview
+4. **Workspace management** - Save/restore window configurations
+5. **Terminal integration** - Send commands to inferior shell/REPL
+
+### LSP Integration
+- `trigger-code-action` - Apply LSP code actions
+- `format-buffer` - Trigger LSP formatting
+- `organize-imports` - Trigger organize imports
+- `get-diagnostics-filtered` - Enhanced diagnostics with filtering (see below)
+
+---
+
+## 6. `get-diagnostics-filtered` - Enhanced LSP Diagnostics with Filtering
+
+**Purpose:** Get LSP diagnostics with filtering options to reduce context window usage and focus on relevant issues.
+
+**Problem with Current `getDiagnostics`:**
+- Returns all diagnostics (errors, warnings, info, hints) for entire file
+- Large files can have 100+ diagnostics consuming significant context
+- No way to paginate or filter results
+- AI assistants waste tokens processing irrelevant warnings
+
+**Parameters:**
+```json
+{
+  "file_path": "/absolute/path/to/file.py",  // required
+  "severity_filter": ["Error", "Warning"],    // optional, default: all severities
+  "line_range": {                             // optional, only diagnostics in range
+    "start": 100,
+    "end": 200
+  },
+  "limit": 20,                                // optional, max diagnostics to return
+  "offset": 0,                                // optional, for pagination
+  "source_filter": ["pylint", "mypy3"]       // optional, filter by diagnostic source
+}
+```
+
+**Returns:**
+```json
+{
+  "diagnostics": [
+    {
+      "line": 42,
+      "column": 10,
+      "severity": "Error",
+      "source": "mypy3",
+      "message": "Incompatible types...",
+      "range": {...}
+    }
+  ],
+  "total_count": 156,        // Total diagnostics before filtering
+  "filtered_count": 20,      // Count after filtering
+  "has_more": true           // Whether there are more results
+}
+```
+
+**Emacs Implementation:**
+```elisp
+(defun claude-code-mcp-get-diagnostics-filtered (file-path &optional severity-filter line-range limit offset source-filter)
+  "Get LSP diagnostics with filtering options.
+FILE-PATH: Absolute path to file
+SEVERITY-FILTER: List of severity levels to include (Error, Warning, Information, Hint)
+LINE-RANGE: Plist with :start and :end line numbers
+LIMIT: Maximum number of diagnostics to return
+OFFSET: Number of diagnostics to skip (for pagination)
+SOURCE-FILTER: List of diagnostic sources to include (pylint, mypy3, etc.)"
+
+  (let* ((buffer (find-buffer-visiting (expand-file-name file-path)))
+         (all-diagnostics (if buffer
+                              (with-current-buffer buffer
+                                (lsp-diagnostics))
+                            nil))
+         (filtered (seq-filter
+                    (lambda (diag)
+                      (let ((severity (lsp:diagnostic-severity diag))
+                            (line (lsp:position-line (lsp:range-start (lsp:diagnostic-range diag))))
+                            (source (lsp:diagnostic-source diag)))
+                        (and
+                         ;; Severity filter
+                         (or (not severity-filter)
+                             (member (lsp-diagnostic-severity-to-string severity) severity-filter))
+                         ;; Line range filter
+                         (or (not line-range)
+                             (and (>= line (plist-get line-range :start))
+                                  (<= line (plist-get line-range :end))))
+                         ;; Source filter
+                         (or (not source-filter)
+                             (member source source-filter)))))
+                    all-diagnostics))
+         (total-count (length all-diagnostics))
+         (filtered-count (length filtered))
+         (paginated (if (and limit offset)
+                        (seq-subseq filtered offset (min (+ offset limit) filtered-count))
+                      filtered))
+         (has-more (and limit offset (< (+ offset (length paginated)) filtered-count))))
+
+    (list :diagnostics (mapcar #'claude-code-mcp-diagnostic-to-json paginated)
+          :total-count total-count
+          :filtered-count filtered-count
+          :has-more has-more)))
+
+(defun claude-code-mcp-diagnostic-to-json (diag)
+  "Convert LSP diagnostic to JSON-friendly format."
+  (let* ((range (lsp:diagnostic-range diag))
+         (start (lsp:range-start range))
+         (line (lsp:position-line start))
+         (column (lsp:position-character start)))
+    (list :line line
+          :column column
+          :severity (lsp-diagnostic-severity-to-string (lsp:diagnostic-severity diag))
+          :source (lsp:diagnostic-source diag)
+          :message (lsp:diagnostic-message diag)
+          :range range)))
+
+(defun lsp-diagnostic-severity-to-string (severity)
+  "Convert LSP severity number to string."
+  (pcase severity
+    (1 "Error")
+    (2 "Warning")
+    (3 "Information")
+    (4 "Hint")
+    (_ "Unknown")))
+```
+
+**Use Cases:**
+
+1. **Errors only (ignore warnings):**
+   ```json
+   {
+     "file_path": "/path/to/file.py",
+     "severity_filter": ["Error"]
+   }
+   ```
+
+2. **Diagnostics in specific function:**
+   ```json
+   {
+     "file_path": "/path/to/file.py",
+     "line_range": {"start": 100, "end": 150},
+     "severity_filter": ["Error", "Warning"]
+   }
+   ```
+
+3. **Paginated results:**
+   ```json
+   {
+     "file_path": "/path/to/file.py",
+     "limit": 10,
+     "offset": 0
+   }
+   ```
+   Then call again with `offset: 10` for next page.
+
+4. **Only mypy errors (ignore pylint style warnings):**
+   ```json
+   {
+     "file_path": "/path/to/file.py",
+     "severity_filter": ["Error"],
+     "source_filter": ["mypy3"]
+   }
+   ```
+
+**Benefits:**
+- **Reduced token usage** - Only get diagnostics you care about
+- **Focus on critical issues** - Filter out style warnings during refactoring
+- **Better UX** - Paginate through large diagnostic lists
+- **Context-aware** - Get diagnostics for specific code regions
+
+**Temporary AI Assistant Workaround (until tool is implemented):**
+
+When calling `mcp__ide__getDiagnostics` and receiving large results, AI assistants should:
+
+1. **Prioritize errors** - Scan results for `"severity": "Error"` entries first
+2. **Ignore style warnings** - Skip pylint warnings like "logging-fstring-interpolation", "too-many-return-statements"
+3. **Focus on type errors** - Pay attention to mypy3 errors about incompatible types
+4. **Report summary** - Tell user "Found X errors, Y warnings" instead of listing all
+5. **Example response:**
+   ```
+   LSP diagnostics show:
+   - 3 mypy type errors (lines 42, 108, 201)
+   - 45 pylint style warnings (can be ignored for now)
+
+   The critical issues are:
+   1. Line 42: Incompatible types in function call
+   2. Line 108: Undefined variable 'foo'
+   3. Line 201: Missing return type annotation
+   ```
+
+**MCP Registration:**
+```elisp
+(claude-code-ide-mcp-register-tool
+ "get-diagnostics-filtered"
+ "Get LSP diagnostics with filtering options to reduce context window usage"
+ '((file_path . string)
+   (severity_filter . array)
+   (line_range . object)
+   (limit . number)
+   (offset . number)
+   (source_filter . array))
+ #'claude-code-mcp-get-diagnostics-filtered)
+```
+
+---
+
+## Questions for Review
+
+1. Should `reload-buffer` auto-reload after every Edit/Write, or require explicit call?
+2. Should `run-elisp` be allowlist-only, or support confirmation dialog?
+3. Should we add a `project_root` parameter to restrict operations to project?
+4. Should navigation commands respect user's window/frame preferences?
+5. Should we add undo/redo support (revert changes via Emacs)?
+
+---
+
+## References
+
+- [MCP Specification](https://spec.modelcontextprotocol.io/)
+- [Emacs Lisp Reference Manual](https://www.gnu.org/software/emacs/manual/elisp.html)
+- [xref API](https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html)
+- [LSP Mode](https://emacs-lsp.github.io/lsp-mode/)

--- a/RESUME_HERE.md
+++ b/RESUME_HERE.md
@@ -1,0 +1,127 @@
+# Resume Point - Buffer Management Simplification
+
+## Current Status
+
+Successfully simplified the buffer management tools by removing the `use_other_window` parameter. The original problem was that Claude was opening files in the Claude terminal window, which was annoying. The fix makes tools **always** open files in another window (not the current one), which is the desired behavior.
+
+## What Was Done
+
+### Code Changes (All Completed ✅)
+
+1. **Simplified `goto-location` function** (`mcp-tools.d/claude-code-ide-tool-buffer-management.el:121-154`)
+   - Removed `use-other-window` parameter
+   - Always opens files in another window using `find-file-other-window`
+   - Always returns focus to original window (Claude terminal)
+   - Updated docstring
+   - Return message now always says "in other window"
+
+2. **Simplified `reload-buffer` function** (`mcp-tools.d/claude-code-ide-tool-buffer-management.el:156-180`)
+   - Removed `use-other-window` parameter
+   - Always displays buffer in another window using `display-buffer`
+   - Always returns focus to original window (Claude terminal)
+   - Updated docstring
+
+3. **Updated tool registrations** (`mcp-tools.d/claude-code-ide-tool-buffer-management.el:197-224`)
+   - Removed `use_other_window` parameter from `goto-location` tool registration (lines 216-219 removed)
+   - Removed `use_other_window` parameter from `reload-buffer` tool registration (lines 229-232 removed)
+
+4. **Deployed to installed package**
+   - Copied file to `~/.emacs.d/elpa/claude-code-ide/mcp-tools.d/`
+   - Recompiled successfully
+   - MCP server restarted
+
+## Next Steps
+
+### 1. Test the Simplified Tools (IMMEDIATE - After Session Restart)
+
+After restarting the Claude Code session, run these tests:
+
+**Test 1: Basic goto-location**
+```
+Use goto-location with file_path=/home/jdblair/src/claude-code-ide.el/claude-code-ide.el, line=100
+```
+**Expected:**
+- File opens in another window (not Claude terminal)
+- Focus returns to Claude terminal
+- Output: "Jumped to .../claude-code-ide.el:100 in other window"
+
+**Test 2: goto-location with highlight**
+```
+Use goto-location with file_path=/home/jdblair/src/claude-code-ide.el/claude-code-ide.el, line=200, highlight=true
+```
+**Expected:**
+- File opens in another window
+- Line 200 briefly highlighted (may be subtle)
+- Focus returns to Claude terminal
+
+**Test 3: reload-buffer**
+```
+Use reload-buffer with file_path=/home/jdblair/src/claude-code-ide.el/claude-code-ide.el
+```
+**Expected:**
+- Buffer reloads from disk
+- Buffer displays in another window
+- Focus returns to Claude terminal
+- Output: "Buffer reloaded from disk: ..."
+
+### 2. Update Documentation
+
+If tests pass, update these files:
+
+**A. Update DEBUGGING_NOTES.md**
+- Add Session 6 section documenting the simplification
+- Explain why we removed the parameter (original problem already solved)
+- Mark the feature as complete
+
+**B. Update test_results.md or remove it**
+- The old test plan tested the `use_other_window=false` option
+- Since we removed that option, the test plan is obsolete
+- Either update with new simpler tests or delete the file
+
+**C. Update CLAUDE.md if needed**
+- The global instructions mention using these tools
+- Verify the instructions are still accurate (should be fine)
+
+### 3. Commit the Changes
+
+Once tests pass and docs are updated:
+
+```bash
+git add mcp-tools.d/claude-code-ide-tool-buffer-management.el
+git commit -m "Simplify buffer management tools - always use other window
+
+Removed use_other_window parameter from goto-location and reload-buffer.
+These tools now always open files in another window and return focus to
+the Claude terminal, which solves the original problem of files opening
+in the Claude terminal window.
+
+The use_other_window parameter was added to provide flexibility, but the
+'open in current window' option isn't needed - the MVP is just 'always
+open in other window'."
+```
+
+## Why We Simplified
+
+The original issue was: "Claude is opening files in the Claude terminal, forcing me to switch back manually."
+
+The fix was: Always open in another window and return focus to the terminal.
+
+We initially added a `use_other_window` parameter with a default of `true` to provide flexibility. But the `use_other_window=false` option (to open in current window) had bugs with JSON boolean handling (`:false` vs `:json-false` vs `'json-false`).
+
+Since the user confirmed they only need the "open in other window" behavior (which is now working), we removed the unnecessary parameter complexity.
+
+## Files Modified
+
+- `/home/jdblair/src/claude-code-ide.el/mcp-tools.d/claude-code-ide-tool-buffer-management.el` - Simplified (source)
+- `~/.emacs.d/elpa/claude-code-ide/mcp-tools.d/claude-code-ide-tool-buffer-management.el` - Deployed and compiled
+
+## Current Branch
+
+`jdb-new-mcp-commands`
+
+## Important Notes
+
+- The MCP server was successfully restarted after the changes
+- The compiled `.elc` file was regenerated
+- A new Claude Code session is needed to reconnect to the updated MCP server
+- Once the session restarts, the simplified tools should work immediately

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,0 +1,219 @@
+# Test Plan: Buffer Management `use_other_window` Feature
+
+**Date:** 2025-11-23
+**Branch:** jdb-new-mcp-commands
+**Commit:** 2e8bbcb
+
+---
+
+## 🚨 RESUME HERE - SESSION 6 🚨
+
+### Status: Fix Applied, Needs Verification
+
+**What happened in Session 5:**
+- ✅ Re-ran all 8 tests, Test 2 failed (use_other_window: false ignored)
+- ✅ Found root cause: Lines 131 & 171 checked for `:false` instead of `:json-false`
+- ✅ Applied correct fix: Changed both to `:json-false` (verified by grepping codebase)
+- ✅ Deployed: Copied to installed package and recompiled
+- ✅ User restarted MCP server
+- ⏳ **Session ended before verification**
+
+**NEXT STEPS - Verify these 3 tests:**
+
+1. **Test 2** - goto-location with use_other_window: false
+   - Should open in CURRENT window (no "in other window" in output)
+
+2. **Test 6** - reload-buffer with use_other_window: false
+   - User visually confirm: opens in current window
+
+3. **Test 4** - goto-location with highlight
+   - User visually confirm: line is highlighted
+
+**If all pass:** Commit the fix
+**If fail:** Check DEBUGGING_NOTES.md Session 5 for troubleshooting steps
+
+---
+
+## Overview
+
+Testing the new `use_other_window` parameter added to buffer management tools:
+- `claude-code-ide-mcp-goto-location`
+- `claude-code-ide-mcp-reload-buffer`
+
+## Prerequisites
+- Claude Code session is active in a terminal buffer
+- At least one other window is visible in Emacs frame
+- Working directory: `/home/jdblair/src/claude-code-ide.el`
+
+---
+
+## Test Cases
+
+### Test 1: goto-location with Default Behavior
+**Command:** Ask Claude to navigate to a specific location without specifying `use_other_window`
+
+**Expected Behavior:**
+- File opens in a **different window** (not the Claude terminal)
+- Cursor jumps to the specified line and column
+- **Focus remains on Claude terminal window**
+- Claude terminal buffer is not replaced
+
+**Example:** "Navigate to line 50 in claude-code-ide.el"
+
+**Status:** ✅ PASS
+
+---
+
+### Test 2: goto-location with use_other_window: false
+**Command:** Explicitly request to open in the current window
+
+**Expected Behavior:**
+- File opens in the **current window** (Claude terminal)
+- Cursor jumps to the specified line
+- **Focus moves to the file buffer** (old behavior)
+- Claude terminal is replaced/hidden
+
+**Example:** "Navigate to line 100 in claude-code-ide.el, opening it in the current window"
+
+**Status:** ❌ FAIL
+
+---
+
+### Test 3: goto-location with use_other_window: true
+**Command:** Explicitly request to open in another window
+
+**Expected Behavior:**
+- Same as Test 1 (should be identical to default)
+- File opens in a different window
+- Focus remains on Claude terminal
+
+**Status:** ⏳ Pending
+
+---
+
+### Test 4: goto-location with Highlight
+**Command:** Navigate to a location with highlighting enabled
+
+**Expected Behavior:**
+- File opens in another window (default behavior)
+- Target line is **temporarily highlighted**
+- **Focus returns to Claude terminal** after highlighting
+- Highlight fades after a moment
+
+**Example:** "Show me line 150 in claude-code-ide-mcp.el and highlight it"
+
+**Status:** ⏳ Pending
+
+---
+
+### Test 5: reload-buffer with Default Behavior
+**Setup:** Make a change to a file outside Emacs, or ask Claude to edit a file first
+
+**Expected Behavior:**
+- Buffer reloads with fresh content from disk
+- Reloaded buffer is **displayed in another window**
+- **Focus remains on Claude terminal**
+- No "file changed on disk" warnings
+
+**Example:** "Reload claude-code-ide.el"
+
+**Status:** ⏳ Pending
+
+---
+
+### Test 6: reload-buffer with use_other_window: false
+**Expected Behavior:**
+- Buffer reloads with fresh content
+- Buffer is **displayed in current window** (Claude terminal)
+- **Focus moves to the reloaded buffer**
+
+**Status:** ⏳ Pending
+
+---
+
+### Test 7: reload-buffer with use_other_window: true
+**Expected Behavior:**
+- Same as Test 5 (identical to default)
+- Buffer displayed in another window
+- Focus remains on Claude terminal
+
+**Status:** ⏳ Pending
+
+---
+
+### Test 8: Tool Schema Verification
+**Command:** List MCP tools to verify parameter is registered
+
+**Expected Behavior:**
+- Both `goto-location` and `reload-buffer` tools show `use_other_window` parameter
+- Parameter is marked as optional
+- Parameter type is `boolean`
+- Description mentions: "Open in another window and keep focus on current window (default: true)"
+
+**Verification:** Check `claude mcp list-tools` or ask Claude to describe the tools
+
+**Status:** ⏳ Pending
+
+---
+
+## Edge Cases to Test
+
+1. **Single window layout:** What happens when there's only one window?
+2. **File already open:** Navigate to a file that's already visible in another window
+3. **Multiple windows:** Verify behavior with 3+ windows visible
+4. **Invalid file path:** Error handling when file doesn't exist
+
+---
+
+## Test Results
+
+Results will be documented here after each test execution.
+
+### Test 1 Results
+- [ ] PASS / [ ] FAIL
+- Notes:
+
+### Test 2 Results
+- [ ] PASS / [ ] FAIL
+- Notes:
+
+### Test 3 Results
+- [ ] PASS / [ ] FAIL
+- Notes:
+
+### Test 4 Results
+- [ ] PASS / [ ] FAIL
+- Notes:
+
+### Test 5 Results
+- [ ] PASS / [ ] FAIL
+- Notes:
+
+### Test 6 Results
+- [ ] PASS / [ ] FAIL
+- Notes:
+
+### Test 7 Results
+- [ ] PASS / [ ] FAIL
+- Notes:
+
+### Test 8 Results
+- [ ] PASS / [ ] FAIL
+- Notes:
+
+---
+
+## Summary
+
+- **Total Tests:** 8
+- **Passed:** 0
+- **Failed:** 0
+- **Pending:** 8
+
+## Issues Found
+
+(Document any issues discovered during testing)
+
+## Conclusion
+
+(Final assessment after all tests complete)

--- a/claude-code-ide-debug.el
+++ b/claude-code-ide-debug.el
@@ -54,9 +54,10 @@
   "Get current session context for logging."
   (if claude-code-ide-log-with-context
       (format "[%s]" (or (ignore-errors
-                           (file-name-nondirectory
-                            (directory-file-name
-                             (project-root (project-current)))))
+                           (when-let ((proj (project-current)))
+                             (file-name-nondirectory
+                              (directory-file-name
+                               (project-root proj)))))
                          "no-project"))
     ""))
 

--- a/claude-code-ide-emacs-tools.el
+++ b/claude-code-ide-emacs-tools.el
@@ -432,7 +432,11 @@ If INCLUDE_CHILDREN is non-nil, include child nodes."
   ;; Enable by setting: (setq claude-code-ide-eval-enabled t)
   ;; Or interactively: M-x claude-code-ide-eval-toggle
   (require 'claude-code-ide-tool-eval)
-  (claude-code-ide-tool-eval-setup))
+  (claude-code-ide-tool-eval-setup)
+
+  ;; Load and register LSP-aware xref tool
+  (require 'claude-code-ide-tool-xref)
+  (claude-code-ide-tool-xref-setup))
 
 ;;;###autoload
 (defun claude-code-ide-emacs-tools-restart ()

--- a/claude-code-ide-emacs-tools.el
+++ b/claude-code-ide-emacs-tools.el
@@ -34,12 +34,17 @@
 (require 'project)
 (require 'cl-lib)
 (require 'imenu)
+(require 'apropos)
 
 ;; Add mcp-tools.d to load-path for modular tools
-(add-to-list 'load-path
-             (expand-file-name "mcp-tools.d"
-                               (file-name-directory
-                                (or load-file-name buffer-file-name))))
+(eval-and-compile
+  (let ((tools-dir (expand-file-name
+                    "mcp-tools.d"
+                    (file-name-directory
+                     (or load-file-name
+                         buffer-file-name
+                         default-directory)))))
+    (add-to-list 'load-path tools-dir)))
 
 ;; Tree-sitter declarations
 (declare-function treesit-node-at "treesit" (pos &optional parser-or-lang named))
@@ -421,7 +426,13 @@ If INCLUDE_CHILDREN is non-nil, include child nodes."
 
   ;; Load and register buffer management tools
   (require 'claude-code-ide-tool-buffer-management)
-  (claude-code-ide-tool-buffer-management-setup))
+  (claude-code-ide-tool-buffer-management-setup)
+
+  ;; Load and register eval tool (OPTIONAL - disabled by default for security)
+  ;; Enable by setting: (setq claude-code-ide-eval-enabled t)
+  ;; Or interactively: M-x claude-code-ide-eval-toggle
+  (require 'claude-code-ide-tool-eval)
+  (claude-code-ide-tool-eval-setup))
 
 ;;;###autoload
 (defun claude-code-ide-emacs-tools-restart ()
@@ -434,10 +445,8 @@ This is useful during development when tools are added or modified."
              claude-code-ide-mcp-server--server)
     (claude-code-ide-mcp-server--stop-server)
     (message "MCP server stopped"))
-  ;; Reload the emacs-tools file
-  (load-file (or load-file-name buffer-file-name))
-  (message "Reloaded claude-code-ide-emacs-tools.el")
-  ;; Re-setup tools (which will restart the server)
+  ;; Just re-setup tools (file is already loaded)
+  ;; If you need to reload from disk, use M-x load-file manually
   (claude-code-ide-emacs-tools-setup)
   (message "MCP tools server restarted"))
 

--- a/demo-goto-location.el
+++ b/demo-goto-location.el
@@ -1,0 +1,71 @@
+;;; demo-goto-location.el --- Demonstrate the gotoLocation MCP tool  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; This script demonstrates the new gotoLocation MCP tool.
+;; To run: M-x eval-buffer in this file
+;;
+;; The demo will jump to 4 different locations in the codebase,
+;; highlighting each location briefly to show the feature in action.
+
+;;; Code:
+
+;; Load the handlers file from the current directory
+(add-to-list 'load-path default-directory)
+(load-file (expand-file-name "claude-code-ide-mcp-handlers.el" default-directory))
+
+(defun demo-goto-location ()
+  "Demonstrate the gotoLocation tool with several examples."
+  (interactive)
+  (message "Starting gotoLocation demonstration...")
+
+  ;; Demo 1: Jump to the goto-location handler itself with highlight
+  (message "Demo 1: Jumping to goto-location handler (line 293) with highlight...")
+  (sit-for 1)
+  (claude-code-ide-mcp-handle-goto-location
+   '((file_path . "/home/jdblair/src/claude-code-ide.el/claude-code-ide-mcp-handlers.el")
+     (line . 293)
+     (highlight . t)))
+
+  (sit-for 2)
+
+  ;; Demo 2: Jump to the test we wrote
+  (message "Demo 2: Jumping to goto-location test (line 1116)...")
+  (sit-for 1)
+  (claude-code-ide-mcp-handle-goto-location
+   '((file_path . "/home/jdblair/src/claude-code-ide.el/claude-code-ide-tests.el")
+     (line . 1116)
+     (column . 0)
+     (highlight . t)))
+
+  (sit-for 2)
+
+  ;; Demo 3: Jump to the tool registration with highlight
+  (message "Demo 3: Jumping to tool registration (line 778)...")
+  (sit-for 1)
+  (claude-code-ide-mcp-handle-goto-location
+   '((file_path . "/home/jdblair/src/claude-code-ide.el/claude-code-ide-mcp-handlers.el")
+     (line . 778)
+     (highlight . t)))
+
+  (sit-for 2)
+
+  ;; Demo 4: Jump to a specific column position
+  (message "Demo 4: Jumping to line 300, column 20...")
+  (sit-for 1)
+  (claude-code-ide-mcp-handle-goto-location
+   '((file_path . "/home/jdblair/src/claude-code-ide.el/claude-code-ide-mcp-handlers.el")
+     (line . 300)
+     (column . 20)
+     (highlight . t)))
+
+  (message "Demo complete! You should have seen 4 different locations with highlighting."))
+
+;; Run the demo
+(demo-goto-location)
+
+;;; demo-goto-location.el ends here

--- a/mcp-tools.d/claude-code-ide-tool-buffer-management.el
+++ b/mcp-tools.d/claude-code-ide-tool-buffer-management.el
@@ -118,17 +118,22 @@ If both are nil, reads the entire buffer."
       (error
        (format "Error reading buffer: %s" (error-message-string err))))))
 
-(defun claude-code-ide-mcp-goto-location (file-path line &optional column highlight)
+(defun claude-code-ide-mcp-goto-location (file-path line &optional column highlight use-other-window)
   "Jump to a specific line and column in a file.
 FILE-PATH is the absolute path to the file.
 LINE is the line number (1-based).
 COLUMN is the column number (0-based, optional).
-HIGHLIGHT temporarily highlights the line if non-nil (optional)."
+HIGHLIGHT temporarily highlights the line if non-nil (optional).
+USE-OTHER-WINDOW if non-nil opens in another window and returns focus (default: t)."
   (claude-code-ide-mcp-server-with-session-context nil
     (condition-case err
-        (progn
-          ;; Open the file
-          (find-file (expand-file-name file-path))
+        (let ((original-window (selected-window))
+              (use-other (if (eq use-other-window 'json-false) nil
+                           (if use-other-window use-other-window t))))
+          ;; Open the file in other window or current window
+          (if use-other
+              (find-file-other-window (expand-file-name file-path))
+            (find-file (expand-file-name file-path)))
           ;; Go to the specified line
           (goto-char (point-min))
           (forward-line (1- line))
@@ -142,27 +147,42 @@ HIGHLIGHT temporarily highlights the line if non-nil (optional)."
             (let ((overlay (make-overlay (line-beginning-position) (line-end-position))))
               (overlay-put overlay 'face 'highlight)
               (run-with-timer 0.5 nil (lambda () (delete-overlay overlay)))))
+          ;; Switch back to the original window if using other window
+          (when (and use-other (window-live-p original-window))
+            (select-window original-window))
           ;; Return success message
-          (format "Jumped to %s:%d%s"
+          (format "Jumped to %s:%d%s%s"
                   file-path
                   line
-                  (if column (format ":%d" column) "")))
+                  (if column (format ":%d" column) "")
+                  (if use-other " in other window" "")))
       (error
        (format "Failed to goto location: %s" (error-message-string err))))))
 
-(defun claude-code-ide-mcp-reload-buffer (file-path)
+(defun claude-code-ide-mcp-reload-buffer (file-path &optional use-other-window)
   "Reload a buffer from disk, syncing with external file modifications.
-FILE-PATH is the absolute path to the file to reload."
+FILE-PATH is the absolute path to the file to reload.
+USE-OTHER-WINDOW if non-nil displays the buffer in another window (default: t)."
   (claude-code-ide-mcp-server-with-session-context nil
     (condition-case err
         (let* ((expanded-path (expand-file-name file-path))
-               (buffer (find-buffer-visiting expanded-path)))
+               (buffer (find-buffer-visiting expanded-path))
+               (original-window (selected-window))
+               (use-other (if (eq use-other-window 'json-false) nil
+                            (if use-other-window use-other-window t))))
           (if buffer
               (progn
                 (with-current-buffer buffer
                   ;; Revert buffer from disk without confirmation
                   ;; Args: ignore-auto noconfirm preserve-modes
                   (revert-buffer t t t))
+                ;; Display the reloaded buffer in another window if requested
+                (when use-other
+                  (display-buffer buffer '(display-buffer-reuse-window
+                                           display-buffer-pop-up-window))
+                  ;; Switch back to original window to keep focus on Claude
+                  (when (window-live-p original-window)
+                    (select-window original-window)))
                 (format "Buffer reloaded from disk: %s" file-path))
             ;; Buffer not currently open - that's fine, just report it
             (format "Buffer not open (no reload needed): %s" file-path)))
@@ -202,6 +222,10 @@ FILE-PATH is the absolute path to the file to reload."
            (:name "highlight"
                   :type boolean
                   :description "Whether to temporarily highlight the line"
+                  :optional t)
+           (:name "use_other_window"
+                  :type boolean
+                  :description "Open in another window and keep focus on current window (default: true)"
                   :optional t)))
 
   ;; Register reload-buffer tool
@@ -211,7 +235,11 @@ FILE-PATH is the absolute path to the file to reload."
    :description "Reload a buffer from disk to sync with external file modifications. Use this after Edit, Write, or shell commands modify files to ensure the user's editor shows the updated content."
    :args '((:name "file_path"
                   :type string
-                  :description "Absolute path to the file to reload")))
+                  :description "Absolute path to the file to reload")
+           (:name "use_other_window"
+                  :type boolean
+                  :description "Display buffer in another window and keep focus on current window (default: true)"
+                  :optional t)))
 
   ;; Register read-buffer tool
   (claude-code-ide-make-tool

--- a/mcp-tools.d/claude-code-ide-tool-buffer-management.el
+++ b/mcp-tools.d/claude-code-ide-tool-buffer-management.el
@@ -1,0 +1,234 @@
+;;; claude-code-ide-tool-buffer-management.el --- Buffer management MCP tools  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025
+
+;; Author: Yoav Orot
+;; Keywords: ai, claude, mcp, buffer
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file provides MCP tools for buffer management operations:
+;; - Listing open buffers
+;; - Reading buffer contents
+;; - Navigating to specific locations
+;; - Reloading buffers from disk
+
+;;; Code:
+
+(require 'claude-code-ide-mcp-server)
+
+;;; Buffer Management Functions
+
+(defun claude-code-ide-mcp-list-buffers (&optional include-internal)
+  "List all open buffers with their key properties.
+Returns a list of buffers with name, file path, modified status, and major mode.
+If INCLUDE-INTERNAL is non-nil, include internal buffers (those starting with space)."
+  (claude-code-ide-mcp-server-with-session-context nil
+    (let ((buffers (buffer-list))
+          (current-buf (current-buffer))
+          (results '()))
+      (dolist (buf buffers)
+        (let ((buf-name (buffer-name buf)))
+          ;; Skip internal buffers unless requested
+          (unless (and (not include-internal)
+                       (string-prefix-p " " buf-name))
+            (with-current-buffer buf
+              (let* ((file-path (buffer-file-name))
+                     (modified (buffer-modified-p))
+                     (mode (symbol-name major-mode))
+                     (is-current (eq buf current-buf))
+                     (size (buffer-size)))
+                (push (format "%s%s%s | %s | %s | %d bytes%s"
+                              (if is-current "* " "  ")
+                              buf-name
+                              (if modified " [modified]" "")
+                              mode
+                              (if file-path
+                                  (abbreviate-file-name file-path)
+                                "(no file)")
+                              size
+                              (if file-path
+                                  (format " | %s" file-path)
+                                ""))
+                      results))))))
+      (if results
+          (string-join (nreverse results) "\n")
+        "No buffers open"))))
+
+(defun claude-code-ide-mcp-read-buffer (buffer-name &optional start-line end-line)
+  "Read contents from BUFFER-NAME.
+BUFFER-NAME can be a buffer name or a file path.
+If START-LINE and END-LINE are provided, read only those lines (1-based).
+Negative values count from the end (e.g., -15 means last 15 lines).
+If only START-LINE is negative, reads that many lines from the end.
+If both are nil, reads the entire buffer."
+  (claude-code-ide-mcp-server-with-session-context nil
+    (condition-case err
+        (let ((buffer (or (get-buffer buffer-name)
+                          (find-buffer-visiting buffer-name))))
+          (if (not buffer)
+              (format "Buffer not found: %s" buffer-name)
+            (with-current-buffer buffer
+              (let* ((total-lines (count-lines (point-min) (point-max)))
+                     ;; Handle negative start-line (e.g., -15 = last 15 lines)
+                     (start (cond ((not start-line) 1)
+                                  ((and (< start-line 0) (not end-line))
+                                   ;; -15 with no end means "last 15 lines"
+                                   (max 1 (+ total-lines start-line 1)))
+                                  ((< start-line 0)
+                                   ;; -15 with end means "15 from end to end"
+                                   (max 1 (+ total-lines start-line 1)))
+                                  (t start-line)))
+                     (end (cond ((not end-line) total-lines)
+                                ((< end-line 0) (max 1 (+ total-lines end-line 1)))
+                                (t end-line))))
+                ;; Validate range
+                (when (> start end)
+                  (error "Invalid range: start-line (%d) > end-line (%d)" start end))
+                (when (> start total-lines)
+                  (error "start-line (%d) exceeds total lines (%d)" start total-lines))
+                (save-excursion
+                  (goto-char (point-min))
+                  (forward-line (1- start))
+                  (let ((start-pos (point)))
+                    (forward-line (- end start))
+                    (end-of-line)
+                    (let ((content (buffer-substring-no-properties start-pos (point))))
+                      (format "Buffer: %s (lines %d-%d of %d)\n%s"
+                              buffer-name
+                              start
+                              end
+                              total-lines
+                              content))))))))
+      (error
+       (format "Error reading buffer: %s" (error-message-string err))))))
+
+(defun claude-code-ide-mcp-goto-location (file-path line &optional column highlight)
+  "Jump to a specific line and column in a file.
+FILE-PATH is the absolute path to the file.
+LINE is the line number (1-based).
+COLUMN is the column number (0-based, optional).
+HIGHLIGHT temporarily highlights the line if non-nil (optional)."
+  (claude-code-ide-mcp-server-with-session-context nil
+    (condition-case err
+        (progn
+          ;; Open the file
+          (find-file (expand-file-name file-path))
+          ;; Go to the specified line
+          (goto-char (point-min))
+          (forward-line (1- line))
+          ;; Go to column if specified
+          (when column
+            (move-to-column column))
+          ;; Recenter to make sure the location is visible
+          (recenter)
+          ;; Highlight if requested
+          (when highlight
+            (let ((overlay (make-overlay (line-beginning-position) (line-end-position))))
+              (overlay-put overlay 'face 'highlight)
+              (run-with-timer 0.5 nil (lambda () (delete-overlay overlay)))))
+          ;; Return success message
+          (format "Jumped to %s:%d%s"
+                  file-path
+                  line
+                  (if column (format ":%d" column) "")))
+      (error
+       (format "Failed to goto location: %s" (error-message-string err))))))
+
+(defun claude-code-ide-mcp-reload-buffer (file-path)
+  "Reload a buffer from disk, syncing with external file modifications.
+FILE-PATH is the absolute path to the file to reload."
+  (claude-code-ide-mcp-server-with-session-context nil
+    (condition-case err
+        (let* ((expanded-path (expand-file-name file-path))
+               (buffer (find-buffer-visiting expanded-path)))
+          (if buffer
+              (progn
+                (with-current-buffer buffer
+                  ;; Revert buffer from disk without confirmation
+                  ;; Args: ignore-auto noconfirm preserve-modes
+                  (revert-buffer t t t))
+                (format "Buffer reloaded from disk: %s" file-path))
+            ;; Buffer not currently open - that's fine, just report it
+            (format "Buffer not open (no reload needed): %s" file-path)))
+      (error
+       (format "Failed to reload buffer: %s" (error-message-string err))))))
+
+;;; Tool Registration
+
+;;;###autoload
+(defun claude-code-ide-tool-buffer-management-setup ()
+  "Register buffer management MCP tools."
+  ;; Register list buffers tool
+  (claude-code-ide-make-tool
+   :function #'claude-code-ide-mcp-list-buffers
+   :name "claude-code-ide-mcp-list-buffers"
+   :description "List all open buffers with their properties including name, file path, modified status, major mode, and size. Shows which buffer is currently active with an asterisk (*)"
+   :args '((:name "include_internal"
+                  :type boolean
+                  :description "Include internal buffers (those starting with space)"
+                  :optional t)))
+
+  ;; Register goto-location tool
+  (claude-code-ide-make-tool
+   :function #'claude-code-ide-mcp-goto-location
+   :name "claude-code-ide-mcp-goto-location"
+   :description "Jump to a specific line and column in a file, optionally highlighting the location. Use this after finding diagnostics or search results to navigate the user's editor to the relevant location."
+   :args '((:name "file_path"
+                  :type string
+                  :description "Absolute path to the file")
+           (:name "line"
+                  :type number
+                  :description "Line number (1-based)")
+           (:name "column"
+                  :type number
+                  :description "Column number (0-based)"
+                  :optional t)
+           (:name "highlight"
+                  :type boolean
+                  :description "Whether to temporarily highlight the line"
+                  :optional t)))
+
+  ;; Register reload-buffer tool
+  (claude-code-ide-make-tool
+   :function #'claude-code-ide-mcp-reload-buffer
+   :name "claude-code-ide-mcp-reload-buffer"
+   :description "Reload a buffer from disk to sync with external file modifications. Use this after Edit, Write, or shell commands modify files to ensure the user's editor shows the updated content."
+   :args '((:name "file_path"
+                  :type string
+                  :description "Absolute path to the file to reload")))
+
+  ;; Register read-buffer tool
+  (claude-code-ide-make-tool
+   :function #'claude-code-ide-mcp-read-buffer
+   :name "claude-code-ide-mcp-read-buffer"
+   :description "Read contents from an arbitrary buffer (including terminal buffers). Can read entire buffer or specific line ranges. Supports negative line numbers to read from the end (e.g., -15 for last 15 lines)."
+   :args '((:name "buffer_name"
+                  :type string
+                  :description "Buffer name or file path")
+           (:name "start_line"
+                  :type number
+                  :description "Starting line number (1-based). Use negative values to count from end (e.g., -15 for last 15 lines)."
+                  :optional t)
+           (:name "end_line"
+                  :type number
+                  :description "Ending line number (1-based). Use negative values to count from end."
+                  :optional t))))
+
+(provide 'claude-code-ide-tool-buffer-management)
+;;; claude-code-ide-tool-buffer-management.el ends here

--- a/mcp-tools.d/claude-code-ide-tool-buffer-management.el
+++ b/mcp-tools.d/claude-code-ide-tool-buffer-management.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025
 
-;; Author: Yoav Orot
+;; Author (this file only): John D. Blair
 ;; Keywords: ai, claude, mcp, buffer
 
 ;; This file is not part of GNU Emacs.

--- a/mcp-tools.d/claude-code-ide-tool-eval.el
+++ b/mcp-tools.d/claude-code-ide-tool-eval.el
@@ -1,0 +1,129 @@
+;;; claude-code-ide-tool-eval.el --- Emacs Lisp evaluation MCP tool  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025
+
+;; Author: Yoav Orot
+;; Keywords: ai, claude, mcp, eval
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file provides an MCP tool for evaluating Emacs Lisp expressions.
+;; This is more efficient than using emacsclient --eval and provides
+;; better error handling and result formatting.
+;;
+;; Security: This tool can execute arbitrary Emacs Lisp code. Use with
+;; caution and only enable when needed. Consider requiring user approval
+;; via Claude Code permissions settings.
+
+;;; Code:
+
+(require 'claude-code-ide-mcp-server)
+
+;;; Customization
+
+(defcustom claude-code-ide-eval-enabled nil
+  "Enable the Emacs Lisp eval MCP tool.
+When nil, the tool will refuse to evaluate code.
+Set to t to enable evaluation."
+  :type 'boolean
+  :group 'claude-code-ide)
+
+(defcustom claude-code-ide-eval-log t
+  "Log all eval calls to the *claude-code-ide-eval-log* buffer.
+This provides an audit trail of all evaluated expressions."
+  :type 'boolean
+  :group 'claude-code-ide)
+
+;;; Eval Functions
+
+(defun claude-code-ide-eval--log (expression result error)
+  "Log EXPRESSION, RESULT, and ERROR to the eval log buffer."
+  (when claude-code-ide-eval-log
+    (with-current-buffer (get-buffer-create "*claude-code-ide-eval-log*")
+      (goto-char (point-max))
+      (insert (format "\n[%s]\n" (format-time-string "%Y-%m-%d %H:%M:%S")))
+      (insert (format "Expression: %s\n" expression))
+      (if error
+          (insert (format "Error: %s\n" error))
+        (insert (format "Result: %s\n" result))))))
+
+(defun claude-code-ide-mcp-eval (expression)
+  "Evaluate EXPRESSION as Emacs Lisp and return the result.
+EXPRESSION should be a string containing valid Emacs Lisp code.
+
+Returns a formatted string with the result or error message.
+
+Security: This function can execute arbitrary code. Only enable via
+claude-code-ide-eval-enabled customization when needed."
+  (claude-code-ide-mcp-server-with-session-context nil
+    (if (not claude-code-ide-eval-enabled)
+        "Eval is disabled. Set claude-code-ide-eval-enabled to t to enable."
+      (condition-case err
+          (let* ((form (read expression))
+                 (result (eval form t))
+                 (result-str (prin1-to-string result)))
+            (claude-code-ide-eval--log expression result-str nil)
+            (format "Expression: %s\nResult: %s\nType: %s"
+                    expression
+                    result-str
+                    (type-of result)))
+        (error
+         (let ((error-msg (error-message-string err)))
+           (claude-code-ide-eval--log expression nil error-msg)
+           (format "Error evaluating expression: %s\nExpression: %s\nError: %s"
+                   expression
+                   error-msg
+                   (prin1-to-string err))))))))
+
+;;;###autoload
+(defun claude-code-ide-eval-show-log ()
+  "Show the eval log buffer."
+  (interactive)
+  (display-buffer (get-buffer-create "*claude-code-ide-eval-log*")))
+
+;;;###autoload
+(defun claude-code-ide-eval-clear-log ()
+  "Clear the eval log buffer."
+  (interactive)
+  (with-current-buffer (get-buffer-create "*claude-code-ide-eval-log*")
+    (erase-buffer)
+    (message "Eval log cleared")))
+
+;;;###autoload
+(defun claude-code-ide-eval-toggle ()
+  "Toggle eval tool enabled/disabled."
+  (interactive)
+  (setq claude-code-ide-eval-enabled (not claude-code-ide-eval-enabled))
+  (message "Claude Code eval tool %s"
+           (if claude-code-ide-eval-enabled "enabled" "disabled")))
+
+;;; Tool Registration
+
+;;;###autoload
+(defun claude-code-ide-tool-eval-setup ()
+  "Register Emacs Lisp eval MCP tool."
+  (claude-code-ide-make-tool
+   :function #'claude-code-ide-mcp-eval
+   :name "claude-code-ide-mcp-eval"
+   :description "Evaluate Emacs Lisp expressions and return results. More efficient than emacsclient --eval with better error handling. All evaluations are logged for audit purposes. Must be explicitly enabled via claude-code-ide-eval-enabled."
+   :args '((:name "expression"
+                  :type string
+                  :description "Emacs Lisp expression to evaluate (as a string)"))))
+
+(provide 'claude-code-ide-tool-eval)
+;;; claude-code-ide-tool-eval.el ends here

--- a/mcp-tools.d/claude-code-ide-tool-xref.el
+++ b/mcp-tools.d/claude-code-ide-tool-xref.el
@@ -1,0 +1,117 @@
+;;; claude-code-ide-tool-xref.el --- LSP-aware xref MCP tool  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025
+
+;; Author: Yoav Orot
+;; Keywords: ai, claude, mcp, xref, lsp
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file provides LSP-aware xref functionality for Claude Code IDE.
+;; The LSP-aware version uses position-based symbol resolution, which is
+;; required for LSP backends (like pylsp, rust-analyzer, etc.) that need
+;; buffer position context to properly resolve symbols.
+;;
+;; For etags/ctags backends, use the standard xref-find-references instead.
+
+;;; Code:
+
+(require 'claude-code-ide-mcp-server)
+(require 'xref)
+
+;;; LSP-Aware XRef Functions
+
+(defun claude-code-ide-mcp-xref-find-references-lsp (identifier file-path)
+  "LSP-aware version: Find references to IDENTIFIER using position-based resolution.
+FILE-PATH specifies which file's buffer context to use for the search.
+
+This version works with LSP backends that require position context to resolve
+symbols. It searches for the identifier in the buffer to get its position,
+then uses xref-backend-identifier-at-point to properly resolve it before
+finding references.
+
+For etags/ctags backends, use claude-code-ide-mcp-xref-find-references instead."
+  (if (not file-path)
+      (error "file_path parameter is required. Please specify the file where you want to search for %s" identifier)
+    (claude-code-ide-mcp-server-with-session-context nil
+      (let ((target-buffer (or (find-buffer-visiting file-path)
+                               (find-file-noselect file-path)))
+            (identifier-str (format "%s" identifier)))
+        (with-current-buffer target-buffer
+          (condition-case err
+              (let ((backend (xref-find-backend)))
+                (if (not backend)
+                    (format "No xref backend available for %s" file-path)
+                  ;; Search for the identifier in the buffer to get position context
+                  (save-excursion
+                    (goto-char (point-min))
+                    (let ((found-pos nil))
+                      ;; Try to find the identifier as a symbol in the buffer
+                      (while (and (not found-pos)
+                                  (search-forward identifier-str nil t))
+                        ;; Check if this is at a symbol boundary
+                        (when (and (or (eolp) (not (looking-at "\\sw\\|\\s_")))
+                                   (save-excursion
+                                     (backward-char (length identifier-str))
+                                     (or (bolp) (not (looking-back "\\sw\\|\\s_" 1)))))
+                          (setq found-pos (- (point) (length identifier-str)))))
+
+                      (if (not found-pos)
+                          (format "Unable to find symbol '%s' in %s. Try navigating to the symbol first."
+                                  identifier-str file-path)
+                        ;; Move to the found position
+                        (goto-char found-pos)
+                        ;; Use xref-backend-identifier-at-point to get proper identifier
+                        (let* ((id (xref-backend-identifier-at-point backend))
+                               (xref-items (when id
+                                             (xref-backend-references backend id))))
+                          (if xref-items
+                              (mapcar (lambda (item)
+                                        (let* ((location (xref-item-location item))
+                                               (file (xref-location-group location))
+                                               (marker (xref-location-marker location))
+                                               (line (with-current-buffer (marker-buffer marker)
+                                                       (save-excursion
+                                                         (goto-char marker)
+                                                         (line-number-at-pos))))
+                                               (summary (xref-item-summary item)))
+                                          (format "%s:%d: %s" file line summary)))
+                                      xref-items)
+                            (format "No references found for '%s'" identifier-str))))))))
+            (error
+             (format "Error searching for '%s' in %s: %s"
+                     identifier-str file-path (error-message-string err)))))))))
+
+;;; Tool Registration
+
+;;;###autoload
+(defun claude-code-ide-tool-xref-setup ()
+  "Register LSP-aware xref MCP tool."
+  (claude-code-ide-make-tool
+   :function #'claude-code-ide-mcp-xref-find-references-lsp
+   :name "claude-code-ide-mcp-xref-find-references-lsp"
+   :description "Find where a function, variable, or class is used (LSP-aware version). Uses position-based symbol resolution for LSP backends like pylsp, rust-analyzer, etc. Works better than the standard version when using Language Server Protocol."
+   :args '((:name "identifier"
+                  :type string
+                  :description "The identifier to find references for")
+           (:name "file_path"
+                  :type string
+                  :description "File path to use as context for the search"))))
+
+(provide 'claude-code-ide-tool-xref)
+;;; claude-code-ide-tool-xref.el ends here

--- a/scripts/compile-and-test.sh
+++ b/scripts/compile-and-test.sh
@@ -63,6 +63,14 @@ if WEBSOCKET_DIR=$(find_emacs_package "emacs-websocket"); then
     LOAD_PATH="$LOAD_PATH -L $WEBSOCKET_DIR"
 fi
 
+if COMPAT_DIR=$(find_emacs_package "compat"); then
+    LOAD_PATH="$LOAD_PATH -L $COMPAT_DIR"
+fi
+
+if COND_LET_DIR=$(find_emacs_package "cond-let"); then
+    LOAD_PATH="$LOAD_PATH -L $COND_LET_DIR"
+fi
+
 if TRANSIENT_DIR=$(find_emacs_package "transient"); then
     LOAD_PATH="$LOAD_PATH -L $TRANSIENT_DIR"
 fi

--- a/test-goto-demo.txt
+++ b/test-goto-demo.txt
@@ -1,0 +1,6 @@
+Line 1: This is a test file
+Line 2: for testing goto-location
+Line 3: and reload-buffer
+Line 4: functionality
+Line 5: in the MCP tools
+Line 6: Testing reload-buffer functionality!


### PR DESCRIPTION
hi Yoav!

i've been having a great time with your claude-code-ide module.
claude-code and i extended it to allow drop-in mcp command definitions, and added some
new ones that i've found useful. eval is particularly fun! use cautiously.

below is the text from claude. if you have time, can you test it? i think its good, but i could
have missed something special about my dev environment. gotoLocation allows claude to
show me places in the code. it also needs a readLocation, but so far i've just been
hacking it by using the eval connector.

with some extra code that i'm not checking in yet, different claude-code-ide instances
can interact with each other in the same emacs environment. after all, they're eval'ing into
the same interpreter! its very meta.

thanks again for putting this together!
John.

## Summary

- Add `gotoLocation` and `reloadBuffer` MCP tools for editor navigation and buffer synchronization
- Refactor MCP tools into modular `mcp-tools.d/` directory structure for better organization
- Add Emacs Lisp `eval` MCP tool (disabled by default, with toggle and audit logging)
- Add `xref` tool for symbol reference lookups via LSP
- Add `use_other_window` parameter to buffer management tools for better window control
- Fix debug mode crash when no project exists

## New MCP Tools

- **gotoLocation** - Jump to specific line/column in a file, with optional highlighting
- **reloadBuffer** - Sync buffer with disk after external modifications
- **eval** - Evaluate Emacs Lisp expressions (security-gated with `claude-code-ide-eval-enabled`)
- **xref** - Find symbol references across the codebase

## Modular Structure

Tools are now organized in `mcp-tools.d/`:
- `claude-code-ide-tool-buffer-management.el` - Buffer operations
- `claude-code-ide-tool-eval.el` - Emacs Lisp evaluation
- `claude-code-ide-tool-xref.el` - LSP xref integration

## Test plan

- [x] All 74 tests pass (66 passed, 8 skipped as expected)
- [x] Byte-compilation succeeds with no errors
- [x] Manual testing of gotoLocation, reloadBuffer, and eval tools
- [x] Verified eval tool is disabled by default and toggle works
