### PR TITLE
Display hl-line and nobreak-space face

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -395,6 +395,12 @@ cursor management, and process buffering for superior user experience."
   (setq-local cursor-in-non-selected-windows nil)
   (setq-local blink-cursor-mode nil)
   (setq-local cursor-type nil)  ; Let vterm handle the cursor entirely
+  ;; disable hl-line-mode, eliminates another source of flicker
+  (setq-local global-hl-line-mode nil)
+  (when (featurep 'hl-line)
+    (hl-line-mode -1))
+  ;; make sure the non-breaking space in the prompt isn't themed
+  (face-remap-add-relative 'nobreak-space :underline nil :foreground nil)
   ;; Register hook for copy-mode cursor visibility
   (add-hook 'vterm-copy-mode-hook #'claude-code-ide--vterm-copy-mode-hook nil t)
   ;; Increase process read buffering to batch more updates together


### PR DESCRIPTION
This eliminates another source of flickering where hl-line will attempt to highlight the bottom most line of the chat window and immediately dismissed on every keystroke.

This PR also prevents themes like Modus from remapping the face of the nobreak-space characters Claude Code puts between the > and the placeholder text.

**Before**:

<img width="1090" height="164" alt="Screenshot 2025-12-13 at 11 59 58 AM" src="https://github.com/user-attachments/assets/49792fa2-6c3a-4878-9621-20b806b97379" />

**After**:

<img width="1090" height="164" alt="Screenshot 2025-12-13 at 12 00 20 PM" src="https://github.com/user-attachments/assets/9e4b8faf-cc45-4315-a856-9cd59a81ac29" />

