### PR TITLE
Hide fake provides from Emacsmirror tooling

### DIFF
--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -100,7 +100,7 @@
    ;; Define the structure accessors to avoid free variable warnings
    (defvar websocket-frame nil)
    (cl-defstruct websocket-frame opcode payload)
-   (provide 'websocket)))
+   (provide (quote websocket))))
 
 ;; === Mock vterm module ===
 (defvar vterm--process nil)
@@ -135,7 +135,7 @@
   "Mock vterm-send-key function for testing."
   nil)
 
-(provide 'vterm)
+(provide (quote vterm))
 
 ;; === Mock Emacs display functions ===
 (unless (fboundp 'display-buffer-in-side-window)
@@ -166,7 +166,7 @@
   buffer checker filename line column end-line end-column
   message level severity id)
 
-(provide 'flycheck)
+(provide (quote flycheck))
 
 ;; === Load required modules ===
 (define-error 'mcp-error "MCP Error" 'error)


### PR DESCRIPTION
This request is part of my long running effort to resolve feature conflicts between packages mirrored on the Emacsmirror (or more precisely my end-of-year push).

Usually when a package provides a foreign feature for testing purposes, I recommend that it be hidden from various tools that automatically detect the features provided and required by a package, by adding a file such as `tests/.nosearch`.  Since the tests are not located in some subdirectory, this won't work here.

Using `(quote ...)` instead of `'...` hides these provides at least from the tooling used by the Emacsmirror, which would have the advantages that this package would not have to appear [here](https://stats.emacsmirror.org/mirror/kludges.html#Drop%20provided%20features), and `epkg-describe-package` would not claim that this package provides these foreign features.

Thanks for considering this!