### PR TITLE
Call global-hl-line-unhighlight to remove existing overlay

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -398,7 +398,8 @@ cursor management, and process buffering for superior user experience."
   ;; disable hl-line-mode, eliminates another source of flicker
   (setq-local global-hl-line-mode nil)
   (when (featurep 'hl-line)
-    (hl-line-mode -1))
+    (hl-line-mode -1)
+    (global-hl-line-unhighlight))
   ;; make sure the non-breaking space in the prompt isn't themed
   (face-remap-add-relative 'nobreak-space :underline nil :foreground nil)
   ;; Register hook for copy-mode cursor visibility


### PR DESCRIPTION
## Summary
- Call `global-hl-line-unhighlight` after disabling hl-line-mode to remove any existing overlay

Setting `global-hl-line-mode` to nil prevents future highlights, but doesn't remove any existing overlay. This ensures the overlay is fully removed when the buffer is configured.

Follows up on #142.