### PR TITLE
fix: Check for empty string in --allowedTools flag

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -765,7 +765,7 @@ Additional flags from `claude-code-ide-cli-extra-flags' are also included."
                    (mapconcat 'identity claude-code-ide-mcp-allowed-tools " "))
                   ;; String pattern or nil
                   (t claude-code-ide-mcp-allowed-tools))))
-            (when allowed-tools
+            (when (and allowed-tools (not (string-empty-p allowed-tools)))
               (setq claude-cmd (concat claude-cmd " --allowedTools " allowed-tools)))))))
     claude-cmd))
 


### PR DESCRIPTION
## Summary
When `claude-code-ide-mcp-allowed-tools` is `'auto` and no tools are registered, `mapconcat` returns an empty string `""` which is truthy in Elisp. This caused the CLI to receive `--allowedTools ` with no value, making it exit immediately.

## Changes
- Add `string-empty-p` check to prevent adding the `--allowedTools` flag when the allowed-tools list is empty

## Root Cause
```elisp
;; mapconcat on empty list returns "", which is truthy
(mapconcat 'identity nil " ")  ; => ""
(if "" "truthy" "falsy")       ; => "truthy"
```

## Test Plan
- [x] Verify CLI starts when no tools are registered with `'auto` mode
- [x] Verify `--allowedTools` flag works correctly when tools ARE registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)