### PR TITLE
Check args fields when setting up a tool

### DIFF
--- a/claude-code-ide-mcp-server.el
+++ b/claude-code-ide-mcp-server.el
@@ -139,6 +139,17 @@ Returns the tool specification for convenience."
       (error "Tool :name is required"))
     (unless description
       (error "Tool :description is required"))
+    (when args
+      (dolist (arg args)
+        (let ((name (plist-get arg :name))
+              (type (plist-get arg :type))
+              (desc (plist-get arg :description)))
+          (unless name
+            (error "Argument :name is required"))
+          (unless type
+            (error "Argument :type is required"))
+          (unless description
+            (error "Argument :description is required")))))
 
     ;; Build the tool specification
     (let ((spec (list :function function


### PR DESCRIPTION
I was getting a similar issue as
https://github.com/manzaltu/claude-code-ide.el/issues/133 where no tools would show up.

Some debugging found this in the debug log:

  Error handling request: Wrong type argument: stringp, nil

The problem was I had not specified args in the right format. I think checking for required field before we add the tool will help prevent this error.