### PR TITLE
Fix vterm--set-size argument count in sync-terminal-dimensions

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -475,7 +475,14 @@ from the window where it was initially created."
       (when-let ((proc (get-buffer-process buffer)))
         (let ((height (window-body-height window))
               (width (window-body-width window)))
-          (set-process-window-size proc height width))))))
+          ;; Update process window size (sends SIGWINCH)
+          (set-process-window-size proc height width)
+          ;; For vterm, also update internal terminal state
+          (when (and (eq major-mode 'vterm-mode)
+                     (fboundp 'vterm--set-size)
+                     (boundp 'vterm--term)
+                     vterm--term)
+            (vterm--set-size vterm--term height width)))))))
 
 (defun claude-code-ide--setup-terminal-keybindings ()
   "Set up keybindings for the Claude Code terminal buffer.


### PR DESCRIPTION
vterm--set-size requires 3 arguments (vterm--term, height, width), not just 2 (height, width). This was causing wrong-number-of-arguments errors when starting new sessions.