### PR TITLE
Optimize vterm smart renderer performance

### DIFF
--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -564,7 +564,10 @@ have completed before cleanup.  Waits up to 5 seconds."
               (claude-code-ide--vterm-smart-renderer orig-fun mock-process complex-input)
               ;; Should be queued, not called immediately
               (should-not orig-fun-called)
-              (should (equal claude-code-ide--vterm-render-queue complex-input))
+              ;; Queue is a list (pushed in reverse order for O(1))
+              (should (listp claude-code-ide--vterm-render-queue))
+              (should (equal (apply #'concat (nreverse claude-code-ide--vterm-render-queue))
+                             complex-input))
               (should (equal timer-created 0.005)))))))))
 
 (ert-deftest claude-code-ide-test-toggle-vterm-optimization ()


### PR DESCRIPTION
- Add early exit for plain text input (no escape sequences) to skip pattern detection overhead during typing
- Change render queue from string concatenation to list-based storage for O(1) push instead of O(n) concat per operation
- Replace split-string + cl-count-if with efficient substring counting