### PR TITLE
Add prompt editing in dedicated buffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -134,6 +134,7 @@ The easiest way to interact with Claude Code IDE is through the transient menu i
 | =M-x claude-code-ide-emacs-tools-setup=   | Set up built-in MCP tools (e.g. xref, project)    |
 | =M-x claude-code-ide=                     | Start Claude Code for the current project         |
 | =M-x claude-code-ide-send-prompt=         | Send prompt to Claude from minibuffer input       |
+| =M-x claude-code-ide-edit-prompt=         | Edit prompt in a dedicated buffer (C-c ')         |
 | =M-x claude-code-ide-continue=            | Continue most recent conversation in directory    |
 | =M-x claude-code-ide-resume=              | Resume Claude Code with previous conversation     |
 | =M-x claude-code-ide-stop=                | Stop Claude Code for the current project          |
@@ -160,6 +161,26 @@ You can run multiple Claude Code instances simultaneously for different projects
 - The window can be closed with standard Emacs window commands (=C-x 0=) without stopping Claude
 - Use =claude-code-ide-toggle-recent= to toggle the most recent Claude window from anywhere, regardless of your current project context. This is useful when you're outside a project directory but want to quickly hide/show Claude
 
+** Editing Prompts in a Dedicated Buffer
+
+For composing longer or more complex prompts, you can use =M-x claude-code-ide-edit-prompt= (or the ='= key in the transient menu) to open a dedicated editing buffer. This works similar to how org-mode's =C-c '= opens a source block for editing.
+
+*** Keybindings in the Edit Buffer
+
+| Keybinding | Action                                      |
+|------------+---------------------------------------------|
+| =C-c '=      | Send prompt to terminal (for review)        |
+| =C-c C-c=    | Send prompt and submit (press Return)       |
+| =C-c C-k=    | Cancel and close without sending            |
+
+This feature gives you full Emacs editing capabilities when composing prompts: syntax highlighting, paredit, spell-check, multiple cursors, and any other editing modes you have configured.
+
+The buffer starts empty. After composing your prompt:
+- Use =C-c '= to send the text to the terminal without submitting, allowing you to review it first
+- Use =C-c C-c= to send and immediately submit the prompt to Claude
+
+Multi-line prompts are automatically handled by inserting the appropriate escape sequences (=\= + Return).
+
 ** Diff Viewing with Ediff
 
 When =claude-code-ide-use-ide-diff= is enabled (default), Claude's code suggestions are displayed using Emacs' powerful =ediff= interface. This provides two key advantages:
@@ -183,8 +204,8 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 
 *** Configuration Variables
 
-| Variable                                      | Description                                 | Default                              |
-|-----------------------------------------------+---------------------------------------------+--------------------------------------|
+| Variable                                        | Description                                 | Default                                |
+|-------------------------------------------------+---------------------------------------------+----------------------------------------|
 | ~claude-code-ide-cli-path~                      | Path to Claude Code CLI                     | ~"claude"~                             |
 | ~claude-code-ide-buffer-name-function~          | Function for buffer naming                  | ~claude-code-ide--default-buffer-name~ |
 | ~claude-code-ide-cli-debug~                     | Enable CLI debug mode (-d flag)             | ~nil~                                  |
@@ -195,7 +216,7 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 | ~claude-code-ide-vterm-render-delay~            | vterm render batching delay (seconds)       | ~0.005~                                |
 | ~claude-code-ide-terminal-initialization-delay~ | Initialization delay for terminals          | ~0.1~                                  |
 | ~claude-code-ide-log-with-context~              | Include session context in log messages     | ~t~                                    |
-| ~claude-code-ide-debug-buffer~                  | Buffer name for debug output                | ~"*claude-code-ide-debug*"~              |
+| ~claude-code-ide-debug-buffer~                  | Buffer name for debug output                | ~"*claude-code-ide-debug*"~            |
 | ~claude-code-ide-use-side-window~               | Use side window vs regular buffer           | ~t~                                    |
 | ~claude-code-ide-window-side~                   | Side for Claude window                      | ~'right~                               |
 | ~claude-code-ide-window-width~                  | Width for side windows (left/right)         | ~90~                                   |
@@ -294,8 +315,8 @@ This delay prevents display artifacts such as misaligned prompts and incorrect c
 
 Claude Code IDE adds custom keybindings to the terminal for easier interaction:
 
-| Keybinding | Command                        | Description                          |
-|------------+--------------------------------+--------------------------------------|
+| Keybinding   | Command                          | Description                          |
+|--------------+----------------------------------+--------------------------------------|
 | =M-RET=      | =claude-code-ide-insert-newline= | Insert a newline in the prompt       |
 | =C-<escape>= | =claude-code-ide-send-escape=    | Send escape key to cancel operations |
 

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -2275,6 +2275,52 @@ have completed before cleanup.  Waits up to 5 seconds."
           (should (equal (plist-get file-path-arg :description)
                          "Path to the file to analyze for symbols")))))))
 
+;;; Prompt Edit Buffer Tests
+
+(ert-deftest claude-code-ide-test-prompt-edit-buffer-name ()
+  "Test prompt edit buffer naming."
+  (let ((mock-terminal-buffer (get-buffer-create "*claude-code[test-project]*")))
+    (unwind-protect
+        (let ((edit-buffer-name (claude-code-ide--prompt-edit-buffer-name mock-terminal-buffer)))
+          (should (equal edit-buffer-name "*claude-prompt-edit[test-project]*")))
+      (kill-buffer mock-terminal-buffer))))
+
+(ert-deftest claude-code-ide-test-prompt-edit-mode-keymap ()
+  "Test that prompt edit mode has correct keybindings."
+  (should (keymapp claude-code-ide-prompt-edit-mode-map))
+  (should (eq (lookup-key claude-code-ide-prompt-edit-mode-map (kbd "C-c '"))
+              'claude-code-ide-prompt-edit-send))
+  (should (eq (lookup-key claude-code-ide-prompt-edit-mode-map (kbd "C-c C-c"))
+              'claude-code-ide-prompt-edit-send-and-submit))
+  (should (eq (lookup-key claude-code-ide-prompt-edit-mode-map (kbd "C-c C-k"))
+              'claude-code-ide-prompt-edit-cancel)))
+
+(ert-deftest claude-code-ide-test-prompt-edit-mode-header-line ()
+  "Test that prompt edit mode sets up header line."
+  (with-temp-buffer
+    (claude-code-ide-prompt-edit-mode 1)
+    (should header-line-format)
+    (should (string-match "Edit prompt" header-line-format))))
+
+(ert-deftest claude-code-ide-test-prompt-edit-cancel ()
+  "Test cancelling prompt edit."
+  (let ((edit-buffer (get-buffer-create "*test-prompt-edit*")))
+    (with-current-buffer edit-buffer
+      (insert "test prompt")
+      (setq-local claude-code-ide-prompt-edit--target-buffer (current-buffer))
+      (claude-code-ide-prompt-edit-mode 1)
+      (claude-code-ide-prompt-edit-cancel))
+    ;; Buffer should be killed
+    (should-not (buffer-live-p edit-buffer))))
+
+(ert-deftest claude-code-ide-test-edit-prompt-no-session ()
+  "Test edit-prompt command when no session exists."
+  (claude-code-ide-tests--clear-processes)
+  (unwind-protect
+      (should-error (claude-code-ide-edit-prompt)
+                    :type 'user-error)
+    (claude-code-ide-tests--clear-processes)))
+
 (provide 'claude-code-ide-tests)
 
 ;; Local Variables:

--- a/claude-code-ide-transient.el
+++ b/claude-code-ide-transient.el
@@ -41,6 +41,7 @@
 (declare-function claude-code-ide-send-prompt "claude-code-ide" ())
 (declare-function claude-code-ide-send-escape "claude-code-ide" ())
 (declare-function claude-code-ide-insert-newline "claude-code-ide" ())
+(declare-function claude-code-ide-edit-prompt "claude-code-ide" ())
 (declare-function claude-code-ide-toggle "claude-code-ide" ())
 (declare-function claude-code-ide-check-status "claude-code-ide" ())
 (declare-function claude-code-ide--ensure-cli "claude-code-ide" ())
@@ -330,6 +331,7 @@ Otherwise, if multiple sessions exist, prompt for selection."
    ["Interaction"
     ("i" "Insert selection" claude-code-ide-insert-at-mentioned)
     ("p" "Send prompt from minibuffer" claude-code-ide-send-prompt)
+    ("'" "Edit prompt in buffer" claude-code-ide-edit-prompt)
     ("e" "Send escape key" claude-code-ide-send-escape)
     ("n" "Insert newline" claude-code-ide-insert-newline)]
    ["Submenus"

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -1219,6 +1219,135 @@ If no Claude windows are visible, show the most recently accessed one."
      (t
       (user-error "No recent Claude Code session to toggle")))))
 
+;;; Prompt Edit Buffer
+
+(defvar-local claude-code-ide-prompt-edit--target-buffer nil
+  "The Claude Code terminal buffer that this edit buffer is associated with.")
+
+(defvar claude-code-ide-prompt-edit-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c '") #'claude-code-ide-prompt-edit-send)
+    (define-key map (kbd "C-c C-c") #'claude-code-ide-prompt-edit-send-and-submit)
+    (define-key map (kbd "C-c C-k") #'claude-code-ide-prompt-edit-cancel)
+    map)
+  "Keymap for `claude-code-ide-prompt-edit-mode'.")
+
+(define-minor-mode claude-code-ide-prompt-edit-mode
+  "Minor mode for editing Claude Code prompts in a dedicated buffer.
+
+\\{claude-code-ide-prompt-edit-mode-map}"
+  :lighter " Claude-Edit"
+  :keymap claude-code-ide-prompt-edit-mode-map
+  (when claude-code-ide-prompt-edit-mode
+    (setq header-line-format
+          (substitute-command-keys
+           "Edit prompt.  \\[claude-code-ide-prompt-edit-send]: send  \
+\\[claude-code-ide-prompt-edit-send-and-submit]: send+submit  \
+\\[claude-code-ide-prompt-edit-cancel]: cancel"))))
+
+(defun claude-code-ide--prompt-edit-buffer-name (terminal-buffer)
+  "Return the name for the prompt edit buffer associated with TERMINAL-BUFFER."
+  (format "*claude-prompt-edit[%s]*"
+          (replace-regexp-in-string
+           "\\*claude-code\\[\\(.*\\)\\]\\*" "\\1"
+           (buffer-name terminal-buffer))))
+
+(defun claude-code-ide--send-prompt-text (text &optional submit)
+  "Send TEXT to the terminal, optionally pressing return if SUBMIT is non-nil.
+Handles multi-line text by converting newlines to backslash+return sequences."
+  (let ((lines (split-string text "\n")))
+    ;; Send each line, inserting backslash+return between lines
+    (dotimes (i (length lines))
+      (let ((line (nth i lines)))
+        (claude-code-ide--terminal-send-string line)
+        ;; If not the last line, send backslash+return for multi-line
+        (when (< i (1- (length lines)))
+          (claude-code-ide--terminal-send-string "\\")
+          (sit-for 0.05)
+          (claude-code-ide--terminal-send-return)
+          (sit-for 0.05)))))
+  ;; Submit if requested
+  (when submit
+    (sit-for 0.1)
+    (claude-code-ide--terminal-send-return)))
+
+(defun claude-code-ide-prompt-edit-send ()
+  "Send the edited prompt to the terminal without pressing return.
+This allows reviewing the prompt in the terminal before submission."
+  (interactive)
+  (unless claude-code-ide-prompt-edit-mode
+    (user-error "Not in a Claude prompt edit buffer"))
+  (let ((text (string-trim (buffer-string)))
+        (target-buffer claude-code-ide-prompt-edit--target-buffer))
+    (unless (and target-buffer (buffer-live-p target-buffer))
+      (user-error "Target Claude buffer no longer exists"))
+    ;; Close the edit window and buffer
+    (let ((edit-window (get-buffer-window (current-buffer))))
+      (kill-buffer (current-buffer))
+      (when (window-live-p edit-window)
+        (delete-window edit-window)))
+    ;; Send to terminal
+    (with-current-buffer target-buffer
+      (claude-code-ide--send-prompt-text text nil))
+    (claude-code-ide-debug "Sent prompt to Claude (no submit): %s" text)))
+
+(defun claude-code-ide-prompt-edit-send-and-submit ()
+  "Send the edited prompt to the terminal and press return to submit."
+  (interactive)
+  (unless claude-code-ide-prompt-edit-mode
+    (user-error "Not in a Claude prompt edit buffer"))
+  (let ((text (string-trim (buffer-string)))
+        (target-buffer claude-code-ide-prompt-edit--target-buffer))
+    (unless (and target-buffer (buffer-live-p target-buffer))
+      (user-error "Target Claude buffer no longer exists"))
+    ;; Close the edit window and buffer
+    (let ((edit-window (get-buffer-window (current-buffer))))
+      (kill-buffer (current-buffer))
+      (when (window-live-p edit-window)
+        (delete-window edit-window)))
+    ;; Send to terminal and submit
+    (with-current-buffer target-buffer
+      (claude-code-ide--send-prompt-text text t))
+    (claude-code-ide-debug "Sent and submitted prompt to Claude: %s" text)))
+
+(defun claude-code-ide-prompt-edit-cancel ()
+  "Cancel editing and close the prompt edit buffer without sending."
+  (interactive)
+  (unless claude-code-ide-prompt-edit-mode
+    (user-error "Not in a Claude prompt edit buffer"))
+  (let ((edit-window (get-buffer-window (current-buffer))))
+    (kill-buffer (current-buffer))
+    (when (window-live-p edit-window)
+      (delete-window edit-window)))
+  (message "Prompt edit cancelled"))
+
+;;;###autoload
+(defun claude-code-ide-edit-prompt ()
+  "Open a buffer to compose a prompt for Claude Code.
+The prompt can be edited with full Emacs editing capabilities.
+
+Keybindings in the edit buffer:
+  C-c '     - Send prompt to terminal (for review, no submit)
+  C-c C-c   - Send prompt and submit (press Return)
+  C-c C-k   - Cancel and close without sending"
+  (interactive)
+  (let ((buffer-name (claude-code-ide--get-buffer-name)))
+    (if-let ((terminal-buffer (get-buffer buffer-name)))
+        (let* ((edit-buffer-name (claude-code-ide--prompt-edit-buffer-name terminal-buffer))
+               (edit-buffer (get-buffer-create edit-buffer-name)))
+          (with-current-buffer edit-buffer
+            (erase-buffer)
+            (text-mode)
+            (claude-code-ide-prompt-edit-mode 1)
+            (setq-local claude-code-ide-prompt-edit--target-buffer terminal-buffer))
+          ;; Display in a window below current
+          (display-buffer edit-buffer
+                          '((display-buffer-below-selected)
+                            (window-height . 10)))
+          (select-window (get-buffer-window edit-buffer))
+          (message "Compose your prompt.  C-c ' to send, C-c C-c to send+submit, C-c C-k to cancel"))
+      (user-error "No Claude Code session for this project"))))
+
 (provide 'claude-code-ide)
 
 ;;; claude-code-ide.el ends here

--- a/scripts/compile-and-test.sh
+++ b/scripts/compile-and-test.sh
@@ -126,6 +126,10 @@ fi
 # STEP 3: Run tests (only if both compilations succeeded)
 TEST_FAILED=0
 if [ $COMPILE_EXIT_CODE -eq 0 ] && [ $NATIVE_COMPILE_EXIT_CODE -eq 0 ]; then
+    # Clean up .elc files before running tests to avoid stale bytecode issues
+    # This ensures tests run against source code and avoids transient version mismatches
+    rm -f *.elc
+    find . -name "*.eln" -type f -delete 2>/dev/null || true
     echo "" >&2
     echo "=== Running tests ===" >&2
     emacs -batch -L . -l ert -l claude-code-ide-tests.el -f ert-run-tests-batch-and-exit >&2


### PR DESCRIPTION
## Summary

Implements feature request from https://github.com/manzaltu/claude-code-ide.el/issues/162

- Add a new feature to edit Claude prompts in a dedicated buffer, similar to org-mode's `C-c '` for source blocks
- Provides full Emacs editing capabilities when composing prompts (syntax highlighting, paredit, spell-check, etc.)
- Multi-line prompts are automatically handled by converting newlines to `\` + Return sequences

## New Commands

| Command | Keybinding | Description |
|---------|------------|-------------|
| `claude-code-ide-edit-prompt` | `'` in menu | Open the edit buffer |
| `claude-code-ide-prompt-edit-send` | `C-c '` | Send text without submitting (for review) |
| `claude-code-ide-prompt-edit-send-and-submit` | `C-c C-c` | Send and submit |
| `claude-code-ide-prompt-edit-cancel` | `C-c C-k` | Cancel editing |

## Other Changes

- Fix `compile-and-test.sh` to clean up `.elc` files before running tests to avoid transient version mismatch issues

## Test plan

- [x] All existing tests pass
- [x] New tests added for prompt edit functionality
- [ ] Manual testing: Open Claude session, use `M-x claude-code-ide-edit-prompt`, compose prompt, test all three keybindings