### PR TITLE
fix: use hl-line-range-function instead of disabling global-hl-line-mode

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -410,8 +410,9 @@ cursor management, and process buffering for superior user experience."
   (setq-local cursor-in-non-selected-windows nil)
   (setq-local blink-cursor-mode nil)
   (setq-local cursor-type nil)  ; Let vterm handle the cursor entirely
-  ;; disable hl-line-mode, eliminates another source of flicker
-  (setq-local global-hl-line-mode nil)
+  ;; Hide hl-line overlay but keep global mode running to run the hooks
+  ;; necessary to clear sticky highlights in other windows.
+  (setq-local hl-line-range-function #'ignore)
   (when (featurep 'hl-line)
     (hl-line-mode -1))
   ;; make sure the non-breaking space in the prompt isn't themed


### PR DESCRIPTION
Setting `global-hl-line-mode` nil buffer-locally prevented `global-hl-line-maybe-unhighlight` from running, leaving stale highlights in the previously selected window. Use `hl-line-range-function` returning nil to make the overlay zero-width (invisible) while keeping the global mode active for proper cleanup.

Small change (3 lines), quick to review.