### PR TITLE
add bookmark support for session buffers

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -1228,10 +1228,10 @@ If no Claude windows are visible, show the most recently accessed one."
 (defun claude-code-ide-bookmark-make-record ()
   "Create a bookmark record for a claude-code-ide buffer."
   `(,(buffer-name)
-    (handler . claude-code-ide-bookmark-handler)
+    (handler . claude-code-ide-bookmark-jump)
     (project-dir . ,(claude-code-ide--get-working-directory))))
 
-(defun claude-code-ide-bookmark-handler (bookmark)
+(defun claude-code-ide-bookmark-jump (bookmark)
   "Restore a claude-code-ide session from BOOKMARK."
   (let* ((project-dir (bookmark-prop-get bookmark 'project-dir))
          (default-directory project-dir)
@@ -1241,6 +1241,8 @@ If no Claude windows are visible, show the most recently accessed one."
         (set-buffer existing-buffer)
       (claude-code-ide--start-session)
       (set-buffer (get-buffer (claude-code-ide--get-buffer-name project-dir))))))
+
+(put 'claude-code-ide-bookmark-jump 'bookmark-handler-type "ClaudIde")
 
 (provide 'claude-code-ide)
 

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -1244,7 +1244,7 @@ If no Claude windows are visible, show the most recently accessed one."
          (existing-buffer (get-buffer buffer-name)))
     (if (and existing-buffer (buffer-live-p existing-buffer))
         (set-buffer existing-buffer)
-      (claude-code-ide--start-session t)
+      (claude-code-ide--start-session)
       (set-buffer (get-buffer (claude-code-ide--get-buffer-name project-dir))))))
 
 (provide 'claude-code-ide)


### PR DESCRIPTION
## Summary
- Set `bookmark-make-record-function` and handler so session buffers can be bookmarked and restored
- Works with activities.el, bufferlo, and any bookmark-based session manager

## Test plan
- [x] Verify bookmark creation in a claude-code-ide buffer with `bookmark-set`
- [x] Verify restore via `bookmark-jump` reopens or switches to existing session