### PR TITLE
Update installation instructions for claude-code-ide

### DIFF
--- a/README.org
+++ b/README.org
@@ -87,7 +87,7 @@ To install using =emacs-version= >= 30 and =use-package= with the =vc= binding:
 
 #+begin_src elisp
 (use-package claude-code-ide
-  :vc (:url "https://github.com/manzaltu/claude-code-ide.el" :rev :newest)
+  :vc (:fetcher github :repo manzaltu/claude-code-ide.el)
   :bind ("C-c C-'" . claude-code-ide-menu) ; Set your favorite keybinding
   :config
   (claude-code-ide-emacs-tools-setup)) ; Optionally enable Emacs MCP tools


### PR DESCRIPTION
The one in the README does not work.

```
⛔ Error (use-package): Failed to parse package claude-code-ide: use-package: :vc declaration contains unknown keywords: :url.  Known keywords are: (:fetcher :repo :rev :backend)
```

This change fixes that