### PR TITLE
Add gterm (ghostty-vt) as terminal backend

### DIFF
--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -956,7 +956,8 @@ Signals an error if terminal fails to initialize."
                   (append env-vars
                           (list (format "TERM=%s" gterm-term-environment-variable)
                                 (format "COLUMNS=%d" cols)
-                                (format "LINES=%d" rows))
+                                (format "LINES=%d" rows)
+                                (format "SHELL=%s" gterm-shell))
                           process-environment)))
             (setq gterm--width cols
                   gterm--height rows

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -942,19 +942,22 @@ Signals an error if terminal fails to initialize."
 
      ;; gterm backend
      ((eq claude-code-ide-terminal-backend 'gterm)
-      (let* ((gterm-shell claude-cmd)
-             (buffer (get-buffer-create buffer-name)))
+      (let* ((buffer (get-buffer-create buffer-name)))
         (with-current-buffer buffer
-          ;; Set up gterm with env vars
-          (setq-local process-environment
-                      (append env-vars process-environment))
-          ;; Initialize gterm mode and terminal
+          ;; Initialize gterm mode first (kills buffer-local vars)
           (unless (eq major-mode 'gterm-mode)
             (gterm-mode))
           ;; Start the shell process with claude command
           (let* ((size (gterm--calculate-size))
                  (cols (car size))
-                 (rows (cdr size)))
+                 (rows (cdr size))
+                 ;; Set env vars AFTER gterm-mode (which kills local vars)
+                 (process-environment
+                  (append env-vars
+                          (list (format "TERM=%s" gterm-term-environment-variable)
+                                (format "COLUMNS=%d" cols)
+                                (format "LINES=%d" rows))
+                          process-environment)))
             (setq gterm--width cols
                   gterm--height rows
                   gterm--term (gterm-new cols rows))

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -963,6 +963,7 @@ Signals an error if terminal fails to initialize."
                    :name "gterm"
                    :buffer buffer
                    :command (split-string-shell-command claude-cmd)
+                   :connection-type 'pty
                    :coding 'no-conversion
                    :filter #'gterm--filter
                    :sentinel #'gterm--sentinel

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -88,6 +88,14 @@
 (declare-function eat-term-display-cursor "eat" (terminal))
 (declare-function eat--adjust-process-window-size "eat" (process windows))
 
+;; External function declarations for gterm
+(defvar gterm-shell)
+(defvar gterm--process)
+(declare-function gterm "gterm" ())
+(declare-function gterm-send-string "gterm" (string))
+(declare-function gterm-send-escape "gterm" ())
+(declare-function gterm-send-return "gterm" ())
+
 ;;; Customization
 
 (defgroup claude-code-ide nil
@@ -212,7 +220,8 @@ and provides a fully-featured terminal emulator.  The eat backend
 is an alternative terminal emulator that may work better in some
 environments."
   :type '(choice (const :tag "vterm" vterm)
-                 (const :tag "eat" eat))
+                 (const :tag "eat" eat)
+                 (const :tag "gterm" gterm))
   :group 'claude-code-ide)
 
 (defcustom claude-code-ide-prevent-reflow-glitch t
@@ -444,8 +453,13 @@ cursor management, and process buffering for superior user experience."
       (require 'eat nil t))
     (unless (featurep 'eat)
       (user-error "The package eat is not installed.  Please install the eat package or change `claude-code-ide-terminal-backend' to 'vterm")))
+   ((eq claude-code-ide-terminal-backend 'gterm)
+    (unless (featurep 'gterm)
+      (require 'gterm nil t))
+    (unless (featurep 'gterm)
+      (user-error "The package gterm is not installed.  Please install gterm or change `claude-code-ide-terminal-backend'")))
    (t
-    (user-error "Invalid terminal backend: %s.  Valid options are 'vterm or 'eat" claude-code-ide-terminal-backend))))
+    (user-error "Invalid terminal backend: %s.  Valid options are 'vterm, 'eat, or 'gterm" claude-code-ide-terminal-backend))))
 
 (defun claude-code-ide--terminal-send-string (string)
   "Send STRING to the terminal in the current buffer."
@@ -455,6 +469,8 @@ cursor management, and process buffering for superior user experience."
    ((eq claude-code-ide-terminal-backend 'eat)
     (when eat-terminal
       (eat-term-send-string eat-terminal string)))
+   ((eq claude-code-ide-terminal-backend 'gterm)
+    (gterm-send-string string))
    (t
     (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))
 
@@ -466,6 +482,8 @@ cursor management, and process buffering for superior user experience."
    ((eq claude-code-ide-terminal-backend 'eat)
     (when eat-terminal
       (eat-term-send-string eat-terminal "\e")))
+   ((eq claude-code-ide-terminal-backend 'gterm)
+    (gterm-send-string "\e"))
    (t
     (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))
 
@@ -477,6 +495,8 @@ cursor management, and process buffering for superior user experience."
    ((eq claude-code-ide-terminal-backend 'eat)
     (when eat-terminal
       (eat-term-send-string eat-terminal "\r")))
+   ((eq claude-code-ide-terminal-backend 'gterm)
+    (gterm-send-string "\r"))
    (t
     (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))
 
@@ -507,6 +527,9 @@ This function binds:
     ;; We use local-set-key to make it buffer-local
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
     (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
+   ((eq claude-code-ide-terminal-backend 'gterm)
+    (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
+    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
    (t
     (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))
 
@@ -523,6 +546,7 @@ This function binds:
   (pcase claude-code-ide-terminal-backend
     ('vterm #'vterm--window-adjust-process-window-size)
     ('eat #'eat--adjust-process-window-size)
+    ('gterm #'gterm--maybe-resize)
     (_ (error "Unsupported terminal backend: %s" claude-code-ide-terminal-backend))))
 
 (defun claude-code-ide--terminal-scroll-mode-active-p ()
@@ -530,6 +554,7 @@ This function binds:
   (pcase claude-code-ide-terminal-backend
     ('vterm (bound-and-true-p vterm-copy-mode))
     ('eat (not (bound-and-true-p eat--semi-char-mode)))
+    ('gterm (bound-and-true-p gterm--copy-mode))
     (_ nil)))
 
 (defun claude-code-ide--session-buffer-p (buffer)
@@ -915,6 +940,39 @@ Signals an error if terminal fails to initialize."
               (error "Failed to create eat process.  Please ensure eat is properly installed"))
             (cons buffer process)))))
 
+     ;; gterm backend
+     ((eq claude-code-ide-terminal-backend 'gterm)
+      (let* ((gterm-shell claude-cmd)
+             (buffer (get-buffer-create buffer-name)))
+        (with-current-buffer buffer
+          ;; Set up gterm with env vars
+          (setq-local process-environment
+                      (append env-vars process-environment))
+          ;; Initialize gterm mode and terminal
+          (unless (eq major-mode 'gterm-mode)
+            (gterm-mode))
+          ;; Start the shell process with claude command
+          (let* ((size (gterm--calculate-size))
+                 (cols (car size))
+                 (rows (cdr size)))
+            (setq gterm--width cols
+                  gterm--height rows
+                  gterm--term (gterm-new cols rows))
+            (setq gterm--process
+                  (make-process
+                   :name "gterm"
+                   :buffer buffer
+                   :command (split-string-shell-command claude-cmd)
+                   :coding 'no-conversion
+                   :filter #'gterm--filter
+                   :sentinel #'gterm--sentinel
+                   :noquery t))
+            (set-process-window-size gterm--process rows cols)))
+        (let ((process (get-buffer-process buffer)))
+          (unless process
+            (error "Failed to create gterm process"))
+          (cons buffer process))))
+
      (t
       (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend)))))
 
@@ -1000,7 +1058,10 @@ This function handles:
                               nil t))
                    ((eq claude-code-ide-terminal-backend 'eat)
                     ;; eat uses kill-buffer-on-exit variable
-                    (setq-local eat-kill-buffer-on-exit t))))
+                    (setq-local eat-kill-buffer-on-exit t))
+                   ((eq claude-code-ide-terminal-backend 'gterm)
+                    ;; gterm cleans up via kill-buffer-hook already
+                    nil)))
                 ;; Stabilization period for terminal layout initialization
                 (sleep-for claude-code-ide-terminal-initialization-delay)
                 ;; Display the buffer in a side window


### PR DESCRIPTION
## Summary

Add support for [emacs-libgterm](https://github.com/rwc9u/emacs-libgterm) as a third terminal backend alongside vterm and eat. gterm is a terminal emulator for Emacs built on [libghostty-vt](https://github.com/ghostty-org/ghostty), the terminal emulation library from the Ghostty terminal emulator.

## Changes

- Add `gterm` option to `claude-code-ide-terminal-backend` customization
- Implement all backend dispatch points: send-string, send-escape, send-return, keybindings, resize handler, scroll mode detection, session creation, and exit hooks
- Set `TERM`, `SHELL`, `COLUMNS`, and `LINES` env vars for proper terminal behavior
- Use PTY connection type for subprocess compatibility

## Configuration

```elisp
(setq claude-code-ide-terminal-backend 'gterm)
```

Requires the [gterm](https://github.com/rwc9u/emacs-libgterm) package to be installed.

## Why gterm?

gterm uses Ghostty's terminal engine which offers SIMD-optimized parsing, better Unicode support, and text reflow on resize. It's the first Emacs terminal emulator built on libghostty.