### PR TITLE
Add TRAMP support for remote SSH/SCP/RSYNC sessions

### DIFF
--- a/claude-code-ide-diagnostics.el
+++ b/claude-code-ide-diagnostics.el
@@ -38,6 +38,10 @@
 
 ;; Forward declarations
 (declare-function claude-code-ide-mcp-session-project-dir "claude-code-ide-mcp" (session))
+(declare-function claude-code-ide-mcp-session-remote-prefix "claude-code-ide-mcp" (session))
+(declare-function claude-code-ide--tramp-remote-p "claude-code-ide" (path))
+(declare-function claude-code-ide--tramp-localname "claude-code-ide" (path))
+(declare-function claude-code-ide--tramp-add-prefix "claude-code-ide" (remote-prefix plain-path))
 
 ;; Flycheck declarations
 (defvar flycheck-current-errors)
@@ -193,15 +197,22 @@ Optional SESSION contains the MCP session context."
   (let* ((uri (alist-get 'uri params))
          (diagnostics-by-file '())
          (project-dir (when session
-                        (claude-code-ide-mcp-session-project-dir session))))
+                        (claude-code-ide-mcp-session-project-dir session)))
+         (remote-prefix (when session
+                          (claude-code-ide-mcp-session-remote-prefix session))))
     (claude-code-ide-debug "Diagnostics handler called with URI: %s, project-dir: %s" uri project-dir)
     (if (and uri (not (string-empty-p uri)))
         ;; Get diagnostics for specific file
-        (let* ((file-path (claude-code-ide-uri-to-file-path uri))
-               (buffer (get-file-buffer (expand-file-name file-path))))
+        (let* ((plain-path (claude-code-ide-uri-to-file-path uri))
+               ;; For remote sessions, add TRAMP prefix to find the buffer
+               (resolved-path (if remote-prefix
+                                  (claude-code-ide--tramp-add-prefix remote-prefix plain-path)
+                                plain-path))
+               (buffer (get-file-buffer (expand-file-name resolved-path))))
           (when buffer
             (let ((diags (claude-code-ide-diagnostics-get-all buffer)))
               (when (> (length diags) 0)
+                ;; Return uri with the original plain path
                 (push `((uri . ,uri)
                         (diagnostics . ,diags))
                       diagnostics-by-file)))))
@@ -212,17 +223,22 @@ Optional SESSION contains the MCP session context."
           (when-let ((file (buffer-file-name buffer)))
             (setq buffer-count (1+ buffer-count))
             ;; Filter by project directory if session is available
-            (when (or (not project-dir)
-                      (string-prefix-p (expand-file-name project-dir)
-                                       (expand-file-name file)))
-              (setq checked-count (1+ checked-count))
-              (claude-code-ide-debug "Checking buffer: %s" file)
-              (let ((diags (claude-code-ide-diagnostics-get-all buffer)))
-                (claude-code-ide-debug "Found %d diagnostics for %s" (length diags) file)
-                (when (> (length diags) 0)
-                  (push `((uri . ,(claude-code-ide-file-path-to-uri file))
-                          (diagnostics . ,diags))
-                        diagnostics-by-file))))))
+            ;; Compare using plain paths to handle TRAMP paths correctly
+            (let ((plain-file (claude-code-ide--tramp-localname file))
+                  (plain-project-dir (when project-dir
+                                       (claude-code-ide--tramp-localname project-dir))))
+              (when (or (not plain-project-dir)
+                        (string-prefix-p (expand-file-name plain-project-dir)
+                                         (expand-file-name plain-file)))
+                (setq checked-count (1+ checked-count))
+                (claude-code-ide-debug "Checking buffer: %s" file)
+                (let ((diags (claude-code-ide-diagnostics-get-all buffer)))
+                  (claude-code-ide-debug "Found %d diagnostics for %s" (length diags) file)
+                  (when (> (length diags) 0)
+                    ;; Return plain path in URI so Claude can understand it
+                    (push `((uri . ,(claude-code-ide-file-path-to-uri plain-file))
+                            (diagnostics . ,diags))
+                          diagnostics-by-file)))))))
         (claude-code-ide-debug "Checked %d/%d buffers with files" checked-count buffer-count)))
     ;; Return JSON-encoded string in content array format
     (let ((json-str (if diagnostics-by-file

--- a/claude-code-ide-emacs-tools.el
+++ b/claude-code-ide-emacs-tools.el
@@ -35,10 +35,25 @@
 (require 'cl-lib)
 (require 'imenu)
 
+;; TRAMP helper declarations
+(declare-function claude-code-ide--tramp-remote-p "claude-code-ide" (path))
+(declare-function claude-code-ide--tramp-localname "claude-code-ide" (path))
+(declare-function claude-code-ide--tramp-add-prefix "claude-code-ide" (remote-prefix plain-path))
+
 ;; Tree-sitter declarations
 (declare-function treesit-node-at "treesit" (pos &optional parser-or-lang named))
 (declare-function treesit-node-text "treesit" (node &optional no-property))
 (declare-function treesit-node-field-name "treesit" (node))
+
+;;; TRAMP Helper
+
+(defun claude-code-ide--tools-resolve-file-path (file-path)
+  "Add TRAMP prefix to FILE-PATH if current session is remote.
+Relies on default-directory being set to the session's project-dir."
+  (let ((prefix (claude-code-ide--tramp-remote-p default-directory)))
+    (if prefix
+        (claude-code-ide--tramp-add-prefix prefix file-path)
+      file-path)))
 
 ;;; Tool Functions
 
@@ -49,9 +64,10 @@ This function uses the session context to operate in the correct project."
   (if (not file-path)
       (error "file_path parameter is required. Please specify the file where you want to search for %s" identifier)
     (claude-code-ide-mcp-server-with-session-context nil
-      (let ((target-buffer (or (find-buffer-visiting file-path)
-                               (find-file-noselect file-path)))
-            (identifier-str (format "%s" identifier)))
+      (let* ((resolved-path (claude-code-ide--tools-resolve-file-path file-path))
+             (target-buffer (or (find-buffer-visiting resolved-path)
+                                (find-file-noselect resolved-path)))
+             (identifier-str (format "%s" identifier)))
         (with-current-buffer target-buffer
           (condition-case err
               (let ((backend (xref-find-backend)))
@@ -61,7 +77,8 @@ This function uses the session context to operate in the correct project."
                     (if xref-items
                         (mapcar (lambda (item)
                                   (let* ((location (xref-item-location item))
-                                         (file (xref-location-group location))
+                                         (file (claude-code-ide--tramp-localname
+                                                (xref-location-group location)))
                                          (marker (xref-location-marker location))
                                          (line (with-current-buffer (marker-buffer marker)
                                                  (save-excursion
@@ -82,9 +99,10 @@ This function uses the session context to operate in the correct project."
   (if (not file-path)
       (error "file_path parameter is required. Please specify the file where you want to search for pattern %s" pattern)
     (claude-code-ide-mcp-server-with-session-context nil
-      (let ((target-buffer (or (find-buffer-visiting file-path)
-                               (find-file-noselect file-path)))
-            (pattern-str (format "%s" pattern)))
+      (let* ((resolved-path (claude-code-ide--tools-resolve-file-path file-path))
+             (target-buffer (or (find-buffer-visiting resolved-path)
+                                (find-file-noselect resolved-path)))
+             (pattern-str (format "%s" pattern)))
         (with-current-buffer target-buffer
           (condition-case err
               (let ((backend (xref-find-backend)))
@@ -103,7 +121,8 @@ This function uses the session context to operate in the correct project."
                     (if xref-items
                         (mapcar (lambda (item)
                                   (let* ((location (xref-item-location item))
-                                         (file (xref-location-group location))
+                                         (file (claude-code-ide--tramp-localname
+                                                (xref-location-group location)))
                                          (marker (xref-location-marker location))
                                          (line (with-current-buffer (marker-buffer marker)
                                                  (save-excursion
@@ -139,8 +158,9 @@ Returns a list of symbols with their types and positions."
       (error "file_path parameter is required")
     (claude-code-ide-mcp-server-with-session-context nil
       (condition-case err
-          (let ((target-buffer (or (find-buffer-visiting file-path)
-                                   (find-file-noselect file-path))))
+          (let* ((resolved-path (claude-code-ide--tools-resolve-file-path file-path))
+                 (target-buffer (or (find-buffer-visiting resolved-path)
+                                    (find-file-noselect resolved-path))))
             (with-current-buffer target-buffer
               ;; Generate or update imenu index
               (imenu--make-index-alist)
@@ -244,8 +264,9 @@ If INCLUDE_CHILDREN is non-nil, include child nodes."
       (condition-case err
           (if (not (treesit-available-p))
               "Tree-sitter is not available in this Emacs build"
-            (let ((target-buffer (or (find-buffer-visiting file-path)
-                                     (find-file-noselect file-path))))
+            (let* ((resolved-path (claude-code-ide--tools-resolve-file-path file-path))
+                   (target-buffer (or (find-buffer-visiting resolved-path)
+                                      (find-file-noselect resolved-path))))
               (with-current-buffer target-buffer
                 (let* ((parsers (treesit-parser-list))
                        (parser (car parsers)))

--- a/claude-code-ide-mcp-handlers.el
+++ b/claude-code-ide-mcp-handlers.el
@@ -41,9 +41,13 @@
 (declare-function claude-code-ide-mcp-session-active-diffs "claude-code-ide-mcp" (session))
 (declare-function claude-code-ide-mcp-session-original-tab "claude-code-ide-mcp" (session))
 (declare-function claude-code-ide-mcp-session-project-dir "claude-code-ide-mcp" (session))
+(declare-function claude-code-ide-mcp-session-remote-prefix "claude-code-ide-mcp" (session))
 (declare-function claude-code-ide-mcp--setup-buffer-cache-hooks "claude-code-ide-mcp" ())
 (declare-function claude-code-ide--get-buffer-name "claude-code-ide" (&optional directory))
 (declare-function claude-code-ide--display-buffer-in-side-window "claude-code-ide" (buffer))
+(declare-function claude-code-ide--tramp-remote-p "claude-code-ide" (path))
+(declare-function claude-code-ide--tramp-localname "claude-code-ide" (path))
+(declare-function claude-code-ide--tramp-add-prefix "claude-code-ide" (remote-prefix plain-path))
 (defvar ediff-control-buffer)
 (defvar ediff-window-setup-function)
 (defvar ediff-split-window-function)
@@ -72,17 +76,35 @@
 
 ;;; Helper Functions
 
+(defun claude-code-ide-mcp--resolve-path (session path)
+  "Convert plain remote PATH to TRAMP path using SESSION's remote-prefix.
+Returns PATH unchanged for local sessions."
+  (if-let ((prefix (when session (claude-code-ide-mcp-session-remote-prefix session))))
+      (claude-code-ide--tramp-add-prefix prefix path)
+    path))
+
+(defun claude-code-ide-mcp--strip-remote-prefix (session path)
+  "Strip TRAMP prefix from PATH for SESSION, returning a plain remote path.
+Returns PATH unchanged for local sessions."
+  (if (when session (claude-code-ide-mcp-session-remote-prefix session))
+      (claude-code-ide--tramp-localname path)
+    path))
+
 (defun claude-code-ide-mcp--find-session-for-file (file-path)
   "Find the MCP session that owns FILE-PATH.
+FILE-PATH may be a plain remote path (no TRAMP prefix) or a local path.
 Returns the session if found, nil otherwise."
   (let ((expanded-file (expand-file-name file-path))
         (found-session nil))
     (catch 'found
       (maphash (lambda (project-dir session)
-                 (when (string-prefix-p (expand-file-name project-dir)
-                                        expanded-file)
-                   (setq found-session session)
-                   (throw 'found t)))
+                 ;; Use plain path for comparison to handle remote TRAMP sessions
+                 ;; where file-path from Claude lacks the TRAMP prefix
+                 (let ((plain-project-dir
+                        (expand-file-name (claude-code-ide--tramp-localname project-dir))))
+                   (when (string-prefix-p plain-project-dir expanded-file)
+                     (setq found-session session)
+                     (throw 'found t))))
                claude-code-ide-mcp--sessions))
     found-session))
 
@@ -107,12 +129,15 @@ If SESSION is provided, use it instead of looking up the current session."
       ;; No session found - return nil
       nil)))
 
-(defun claude-code-ide-mcp--create-diff-buffers (old-file-path new-file-contents tab-name)
+(defun claude-code-ide-mcp--create-diff-buffers (old-file-path new-file-contents tab-name &optional session)
   "Create buffers for diff comparison.
 OLD-FILE-PATH is the path to the original file.
 NEW-FILE-CONTENTS is the new content to diff against.
 TAB-NAME is used for naming the new buffer.
+Optional SESSION provides TRAMP context for resolving remote paths.
 Returns a cons cell (buffer-A . buffer-B)."
+  ;; Resolve path: add TRAMP prefix for remote sessions
+  (setq old-file-path (claude-code-ide-mcp--resolve-path session old-file-path))
   (let ((file-exists (file-exists-p old-file-path))
         buffer-A buffer-B)
     ;; Create or find buffer A (original file)
@@ -225,14 +250,15 @@ STARTUP-HOOK-FN is the hook function to remove after use."
 
 ;;; Tool Handler Functions
 
-(defun claude-code-ide-mcp-handle-open-file (arguments)
+(defun claude-code-ide-mcp-handle-open-file (arguments &optional session)
   "Open a file with optional text selection.
 ARGUMENTS should contain:
 - `path': File path to open
 - `startLine' (optional): Start line for selection
 - `endLine' (optional): End line for selection
 - `startText' (optional): Start text pattern for selection
-- `endText' (optional): End text pattern for selection"
+- `endText' (optional): End text pattern for selection
+Optional SESSION provides TRAMP context for remote paths."
   (let ((path (alist-get 'path arguments))
         (start-line (alist-get 'startLine arguments))
         (end-line (alist-get 'endLine arguments))
@@ -240,6 +266,8 @@ ARGUMENTS should contain:
         (end-text (alist-get 'endText arguments)))
     (unless path
       (signal 'mcp-error '("Missing required parameter: path")))
+    ;; Resolve path: add TRAMP prefix for remote sessions
+    (setq path (claude-code-ide-mcp--resolve-path session path))
     (condition-case err
         (progn
           (find-file path)
@@ -290,11 +318,17 @@ ARGUMENTS should contain:
        (signal 'mcp-error (list (format "Failed to open file: %s"
                                         (error-message-string err))))))))
 
-(defun claude-code-ide-mcp-handle-get-current-selection (_arguments)
-  "Get the currently selected text and its context."
-  (let ((file-path (or (buffer-file-name) ""))
-        (file-url (when (buffer-file-name)
-                    (concat "file://" (buffer-file-name)))))
+(defun claude-code-ide-mcp-handle-get-current-selection (_arguments &optional session)
+  "Get the currently selected text and its context.
+Optional SESSION provides TRAMP context for stripping remote prefixes."
+  (let* ((raw-file-path (buffer-file-name))
+         ;; Strip TRAMP prefix so Claude sees plain remote paths
+         (file-path (if raw-file-path
+                        (claude-code-ide--tramp-localname raw-file-path)
+                      ""))
+         (file-url (when raw-file-path
+                     (concat "file://" file-path))))
+    (ignore session)
     (if (use-region-p)
         (let* ((start (region-beginning))
                (end (region-end))
@@ -327,30 +361,39 @@ ARGUMENTS should contain:
                                 (character . ,cursor-col)))
                         (isEmpty . t))))))))
 
-(defun claude-code-ide-mcp-handle-get-open-editors (_arguments)
-  "Get list of all open editors/buffers with file paths."
+(defun claude-code-ide-mcp-handle-get-open-editors (_arguments &optional session)
+  "Get list of all open editors/buffers with file paths.
+Optional SESSION provides TRAMP context for stripping remote prefixes."
   (let ((editors '())
         (project-dir (claude-code-ide-mcp--get-buffer-project)))
+    (ignore session)
     (dolist (buffer (buffer-list))
       (when-let ((file (buffer-file-name buffer)))
         ;; Only include files within the project directory
+        ;; Compare using plain paths to handle TRAMP paths correctly
         (when (or (not project-dir)
-                  (string-prefix-p (expand-file-name project-dir)
-                                   (expand-file-name file)))
-          (push `((path . ,file)
-                  (name . ,(buffer-name buffer))
-                  (active . ,(eq buffer (current-buffer)))
-                  (isDirty . ,(if (buffer-modified-p buffer) t :json-false))
-                  (fileUrl . ,(concat "file://" file)))
-                editors))))
+                  (string-prefix-p (expand-file-name (claude-code-ide--tramp-localname project-dir))
+                                   (expand-file-name (claude-code-ide--tramp-localname file))))
+          ;; Strip TRAMP prefix so Claude sees plain remote paths
+          (let ((plain-path (claude-code-ide--tramp-localname file)))
+            (push `((path . ,plain-path)
+                    (name . ,(buffer-name buffer))
+                    (active . ,(eq buffer (current-buffer)))
+                    (isDirty . ,(if (buffer-modified-p buffer) t :json-false))
+                    (fileUrl . ,(concat "file://" plain-path)))
+                  editors)))))
     `((editors . ,(vconcat (nreverse editors))))))
 
-(defun claude-code-ide-mcp-handle-get-workspace-folders (_arguments)
-  "Get the current workspace folders (project roots)."
+(defun claude-code-ide-mcp-handle-get-workspace-folders (_arguments &optional session)
+  "Get the current workspace folders (project roots).
+Optional SESSION provides TRAMP context for stripping remote prefixes."
   ;; Return the specific project directory for this MCP instance
-  (let ((project-dir (or (claude-code-ide-mcp--get-buffer-project)
-                         default-directory)))
-    `((folders . ,(vconcat (list (expand-file-name project-dir)))))))
+  (let* ((project-dir (or (claude-code-ide-mcp--get-buffer-project)
+                          default-directory))
+         ;; Strip TRAMP prefix so Claude sees plain remote paths
+         (plain-dir (claude-code-ide--tramp-localname (expand-file-name project-dir))))
+    (ignore session)
+    `((folders . ,(vconcat (list plain-dir))))))
 
 (defun claude-code-ide-mcp-handle-get-diagnostics (arguments &optional session)
   "Get diagnostics (errors/warnings) for the current workspace.
@@ -358,12 +401,15 @@ ARGUMENTS may contain an optional `uri' parameter.
 Optional SESSION contains the MCP session context."
   (claude-code-ide-diagnostics-handler arguments session))
 
-(defun claude-code-ide-mcp-handle-save-document (arguments)
+(defun claude-code-ide-mcp-handle-save-document (arguments &optional session)
   "Save a document.
-ARGUMENTS should contain `path' of the file to save."
+ARGUMENTS should contain `path' of the file to save.
+Optional SESSION provides TRAMP context for remote paths."
   (let ((path (alist-get 'path arguments)))
     (unless path
       (signal 'mcp-error '("Missing required parameter: path")))
+    ;; Resolve path: add TRAMP prefix for remote sessions
+    (setq path (claude-code-ide-mcp--resolve-path session path))
     (condition-case err
         (let ((buffer (find-buffer-visiting path)))
           (if buffer
@@ -511,7 +557,7 @@ ARGUMENTS should contain:
     ;; Save current window configuration
     (let* ((saved-winconf (current-window-configuration))
            (buffers (claude-code-ide-mcp--create-diff-buffers
-                     old-file-path new-file-contents tab-name))
+                     old-file-path new-file-contents tab-name session))
            (buffer-A (car buffers))
            (buffer-B (cdr buffers))
            (file-exists (file-exists-p old-file-path)))
@@ -714,12 +760,15 @@ SESSION is the MCP session to use - if not provided, tries to determine it."
     (list `((type . "text")
             (text . ,(format "CLOSED_%d_DIFF_TABS" closed-count))))))
 
-(defun claude-code-ide-mcp-handle-check-document-dirty (arguments)
+(defun claude-code-ide-mcp-handle-check-document-dirty (arguments &optional session)
   "Check if document is dirty.
-ARGUMENTS should contain `filePath`."
+ARGUMENTS should contain `filePath`.
+Optional SESSION provides TRAMP context for remote paths."
   (let ((path (alist-get 'filePath arguments)))
     (unless path
       (signal 'mcp-error '("Missing required parameter: filePath")))
+    ;; Resolve path: add TRAMP prefix for remote sessions
+    (setq path (claude-code-ide-mcp--resolve-path session path))
     (let ((buffer (find-buffer-visiting path)))
       (if buffer
           `((isDirty . ,(if (buffer-modified-p buffer) t :json-false)))

--- a/claude-code-ide-mcp.el
+++ b/claude-code-ide-mcp.el
@@ -29,6 +29,10 @@
 ;;; Code:
 
 ;; Declare external functions for byte-compilation
+(declare-function claude-code-ide--tramp-remote-p "claude-code-ide" (path))
+(declare-function claude-code-ide--tramp-localname "claude-code-ide" (path))
+(declare-function claude-code-ide--tramp-add-prefix "claude-code-ide" (remote-prefix plain-path))
+(declare-function claude-code-ide--tramp-remote-home "claude-code-ide" (remote-prefix))
 (declare-function websocket-server "websocket" (port &rest plist))
 (declare-function websocket-server-close "websocket" (server))
 (declare-function websocket-server-filter "websocket" (proc string))
@@ -117,7 +121,8 @@ Set to nil when cache needs to be invalidated.")
   last-selection   ; Last selection state
   last-buffer      ; Last active buffer
   active-diffs     ; Hash table of active diffs
-  original-tab)    ; Original tab-bar tab where Claude was opened
+  original-tab     ; Original tab-bar tab where Claude was opened
+  remote-prefix)   ; TRAMP prefix string if remote (e.g. "/ssh:host:"), nil for local
 
 (defun claude-code-ide-mcp--get-buffer-project ()
   "Get the project directory for the current buffer.
@@ -173,19 +178,28 @@ Returns the session if found, nil otherwise."
 
 ;;; Lockfile Management
 
-(defun claude-code-ide-mcp--lockfile-directory ()
-  "Return the directory for MCP lockfiles."
-  (expand-file-name "~/.claude/ide/"))
+(defun claude-code-ide-mcp--lockfile-directory (&optional remote-prefix)
+  "Return the directory for MCP lockfiles.
+If REMOTE-PREFIX is provided, returns the TRAMP path on the remote host."
+  (let ((plain-dir "~/.claude/ide/"))
+    (if remote-prefix
+        (claude-code-ide--tramp-add-prefix remote-prefix
+                                           (expand-file-name plain-dir))
+      (expand-file-name plain-dir))))
 
-(defun claude-code-ide-mcp--lockfile-path (port)
-  "Return the lockfile path for PORT."
-  (format "%s%d.lock" (claude-code-ide-mcp--lockfile-directory) port))
+(defun claude-code-ide-mcp--lockfile-path (port &optional remote-prefix)
+  "Return the lockfile path for PORT.
+If REMOTE-PREFIX is provided, returns the TRAMP path on the remote host."
+  (let ((dir (claude-code-ide-mcp--lockfile-directory remote-prefix)))
+    (format "%s%d.lock" dir port)))
 
 (defun claude-code-ide-mcp--create-lockfile (port project-dir)
   "Create a lockfile for PORT with server information for PROJECT-DIR."
-  (let* ((lockfile-dir (claude-code-ide-mcp--lockfile-directory))
-         (lockfile-path (claude-code-ide-mcp--lockfile-path port))
-         (workspace-folders (vector project-dir))
+  (let* ((remote-prefix (claude-code-ide--tramp-remote-p project-dir))
+         (lockfile-dir (claude-code-ide-mcp--lockfile-directory remote-prefix))
+         (lockfile-path (claude-code-ide-mcp--lockfile-path port remote-prefix))
+         ;; workspaceFolders uses plain remote path (strip TRAMP prefix)
+         (workspace-folders (vector (claude-code-ide--tramp-localname project-dir)))
          (lockfile-content `((pid . ,(emacs-pid))
                              (workspaceFolders . ,workspace-folders)
                              (ideName . "Emacs")
@@ -200,10 +214,14 @@ Returns the session if found, nil otherwise."
        (claude-code-ide-debug "Failed to create lockfile: %s" err)
        (signal 'mcp-error (list (format "Failed to create lockfile: %s" (error-message-string err))))))))
 
-(defun claude-code-ide-mcp--remove-lockfile (port)
-  "Remove the lockfile for PORT."
+(defun claude-code-ide-mcp--remove-lockfile (port &optional project-dir)
+  "Remove the lockfile for PORT.
+If PROJECT-DIR is provided, use it to determine the lockfile location
+(needed for remote TRAMP sessions)."
   (when port
-    (let ((lockfile-path (claude-code-ide-mcp--lockfile-path port)))
+    (let* ((remote-prefix (when project-dir
+                            (claude-code-ide--tramp-remote-p project-dir)))
+           (lockfile-path (claude-code-ide-mcp--lockfile-path port remote-prefix)))
       (claude-code-ide-debug "Attempting to remove lockfile: %s" lockfile-path)
       (if (file-exists-p lockfile-path)
           (progn
@@ -346,7 +364,13 @@ Optional SESSION contains the MCP session context."
         (condition-case err
             (progn
               (claude-code-ide-debug "Found handler for tool: %s" tool-name)
-              (let ((result (if (member tool-name '("getDiagnostics"))
+              (let ((result (if (member tool-name '("getDiagnostics"
+                                                   "openFile"
+                                                   "saveDocument"
+                                                   "checkDocumentDirty"
+                                                   "getOpenEditors"
+                                                   "getWorkspaceFolders"
+                                                   "getCurrentSelection"))
                                 ;; Pass session to handlers that need it
                                 (funcall handler arguments session)
                               (funcall handler arguments))))
@@ -824,7 +848,8 @@ This should be called when the buffer's context might have changed."
                        :deferred (make-hash-table :test 'equal)
                        :active-diffs (make-hash-table :test 'equal)
                        :original-tab (when (fboundp 'tab-bar--current-tab)
-                                       (tab-bar--current-tab))))
+                                       (tab-bar--current-tab))
+                       :remote-prefix (claude-code-ide--tramp-remote-p project-dir)))
              (server-and-port (claude-code-ide-mcp--find-free-port))
              (server (car server-and-port))
              (port (cdr server-and-port)))
@@ -867,7 +892,7 @@ This should be called when the buffer's context might have changed."
     ;; Remove lockfile
     (when-let ((port (claude-code-ide-mcp-session-port session)))
       (claude-code-ide-debug "Removing lockfile for port %d" port)
-      (claude-code-ide-mcp--remove-lockfile port))
+      (claude-code-ide-mcp--remove-lockfile port project-dir))
 
     ;; Remove session from registry
     (remhash project-dir claude-code-ide-mcp--sessions)

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -2275,6 +2275,217 @@ have completed before cleanup.  Waits up to 5 seconds."
           (should (equal (plist-get file-path-arg :description)
                          "Path to the file to analyze for symbols")))))))
 
+;;; TRAMP Support Tests
+
+(ert-deftest claude-code-ide-test-tramp-remote-p-local ()
+  "Test that local paths return nil for remote check."
+  ;; Local paths should return nil
+  (should (null (claude-code-ide--tramp-remote-p "/home/user/project/")))
+  (should (null (claude-code-ide--tramp-remote-p "/tmp/file.el")))
+  (should (null (claude-code-ide--tramp-remote-p nil))))
+
+(ert-deftest claude-code-ide-test-tramp-remote-p-ssh ()
+  "Test that SSH TRAMP paths return the prefix."
+  ;; Mock file-remote-p for our fake TRAMP path
+  (cl-letf (((symbol-function 'file-remote-p)
+             (lambda (path &optional id connected)
+               (cond
+                ((string-prefix-p "/mock-ssh:host:" path)
+                 (cond
+                  ((eq id 'method) "ssh")
+                  ((eq id 'localname) (substring path (length "/mock-ssh:host:")))
+                  (t "/mock-ssh:host:")))
+                (t nil)))))
+    ;; SSH paths should return the TRAMP prefix
+    (should (equal (claude-code-ide--tramp-remote-p "/mock-ssh:host:/home/user/project/")
+                   "/mock-ssh:host:"))))
+
+(ert-deftest claude-code-ide-test-tramp-localname ()
+  "Test TRAMP localname extraction."
+  ;; Local paths return unchanged
+  (should (equal (claude-code-ide--tramp-localname "/home/user/project/") "/home/user/project/"))
+  ;; TRAMP paths return just the local part
+  (cl-letf (((symbol-function 'file-remote-p)
+             (lambda (path &optional id connected)
+               (when (string-prefix-p "/mock-ssh:host:" path)
+                 (when (eq id 'localname)
+                   (substring path (length "/mock-ssh:host:")))))))
+    (should (equal (claude-code-ide--tramp-localname "/mock-ssh:host:/home/user/project/")
+                   "/home/user/project/"))))
+
+(ert-deftest claude-code-ide-test-tramp-add-prefix ()
+  "Test prepending TRAMP prefix to plain path."
+  (should (equal (claude-code-ide--tramp-add-prefix "/ssh:host:" "/home/user/file.py")
+                 "/ssh:host:/home/user/file.py"))
+  (should (equal (claude-code-ide--tramp-add-prefix "/ssh:user@host:" "/tmp/script.sh")
+                 "/ssh:user@host:/tmp/script.sh")))
+
+(ert-deftest claude-code-ide-test-mcp-resolve-path-local ()
+  "Test that path resolution is a no-op for local sessions."
+  (let ((local-session (make-claude-code-ide-mcp-session
+                        :project-dir "/home/user/project/"
+                        :remote-prefix nil)))
+    (should (equal (claude-code-ide-mcp--resolve-path local-session "/home/user/project/file.py")
+                   "/home/user/project/file.py"))
+    ;; nil session also passes through
+    (should (equal (claude-code-ide-mcp--resolve-path nil "/home/user/file.py")
+                   "/home/user/file.py"))))
+
+(ert-deftest claude-code-ide-test-mcp-resolve-path-remote ()
+  "Test that path resolution adds TRAMP prefix for remote sessions."
+  (let ((remote-session (make-claude-code-ide-mcp-session
+                         :project-dir "/mock-ssh:host:/home/user/project/"
+                         :remote-prefix "/mock-ssh:host:")))
+    (should (equal (claude-code-ide-mcp--resolve-path remote-session "/home/user/project/file.py")
+                   "/mock-ssh:host:/home/user/project/file.py"))))
+
+(ert-deftest claude-code-ide-test-mcp-strip-remote-prefix-local ()
+  "Test that prefix stripping is a no-op for local sessions."
+  (let ((local-session (make-claude-code-ide-mcp-session
+                        :project-dir "/home/user/project/"
+                        :remote-prefix nil)))
+    (should (equal (claude-code-ide-mcp--strip-remote-prefix local-session "/home/user/project/file.py")
+                   "/home/user/project/file.py"))))
+
+(ert-deftest claude-code-ide-test-mcp-strip-remote-prefix-remote ()
+  "Test that prefix stripping removes TRAMP prefix for remote sessions."
+  (let ((remote-session (make-claude-code-ide-mcp-session
+                         :project-dir "/mock-ssh:host:/home/user/project/"
+                         :remote-prefix "/mock-ssh:host:")))
+    (cl-letf (((symbol-function 'file-remote-p)
+               (lambda (path &optional id connected)
+                 (when (string-prefix-p "/mock-ssh:host:" path)
+                   (when (eq id 'localname)
+                     (substring path (length "/mock-ssh:host:")))))))
+      (should (equal (claude-code-ide-mcp--strip-remote-prefix
+                      remote-session "/mock-ssh:host:/home/user/project/file.py")
+                     "/home/user/project/file.py")))))
+
+(ert-deftest claude-code-ide-test-mcp-find-session-for-file-local ()
+  "Test find-session-for-file with local paths."
+  (let ((claude-code-ide-mcp--sessions (make-hash-table :test 'equal))
+        (temp-dir (make-temp-file "claude-tramp-test-" t)))
+    (unwind-protect
+        (progn
+          (let ((session (make-claude-code-ide-mcp-session
+                          :project-dir temp-dir
+                          :remote-prefix nil)))
+            (puthash temp-dir session claude-code-ide-mcp--sessions)
+            ;; A file in the project directory should be found
+            (let ((test-file (expand-file-name "file.py" temp-dir)))
+              (should (eq (claude-code-ide-mcp--find-session-for-file test-file) session)))
+            ;; A file outside should not be found
+            (should (null (claude-code-ide-mcp--find-session-for-file "/tmp/other/file.py")))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest claude-code-ide-test-mcp-find-session-for-file-remote ()
+  "Test find-session-for-file with remote TRAMP paths.
+Claude sends plain remote paths; sessions are keyed by TRAMP paths."
+  (let ((claude-code-ide-mcp--sessions (make-hash-table :test 'equal)))
+    (cl-letf (((symbol-function 'file-remote-p)
+               (lambda (path &optional id connected)
+                 (when (string-prefix-p "/mock-ssh:host:" path)
+                   (cond
+                    ((eq id 'localname) (substring path (length "/mock-ssh:host:")))
+                    ((eq id 'method) "ssh")
+                    (t "/mock-ssh:host:"))))))
+      (let* ((tramp-project-dir "/mock-ssh:host:/home/user/project/")
+             (session (make-claude-code-ide-mcp-session
+                       :project-dir tramp-project-dir
+                       :remote-prefix "/mock-ssh:host:")))
+        (puthash tramp-project-dir session claude-code-ide-mcp--sessions)
+        ;; Claude sends a plain remote path (no TRAMP prefix)
+        (should (eq (claude-code-ide-mcp--find-session-for-file
+                     "/home/user/project/src/file.py")
+                    session))
+        ;; File outside project should not be found
+        (should (null (claude-code-ide-mcp--find-session-for-file
+                       "/home/otheruser/file.py")))))))
+
+(ert-deftest claude-code-ide-test-build-remote-ssh-command ()
+  "Test SSH command construction for remote sessions."
+  (cl-letf (((symbol-function 'file-remote-p)
+             (lambda (path &optional id connected)
+               (when (string-prefix-p "/mock-ssh:host:" path)
+                 (cond
+                  ((eq id 'user) nil)
+                  ((eq id 'host) "myhost")
+                  (t "/mock-ssh:host:"))))))
+    (let ((claude-code-ide-tramp-ssh-extra-args ""))
+      (let ((cmd (claude-code-ide--build-remote-ssh-command
+                  "/mock-ssh:host:" 8800 12345 "/home/user/.claude/ide/launch-123.sh")))
+        ;; Should contain -R port forwarding for WebSocket port
+        (should (string-match-p "-R 8800:localhost:8800" cmd))
+        ;; Should contain -R port forwarding for HTTP port
+        (should (string-match-p "-R 12345:localhost:12345" cmd))
+        ;; Should contain the host
+        (should (string-match-p "myhost" cmd))
+        ;; Should contain the script path
+        (should (string-match-p "/home/user/.claude/ide/launch-123.sh" cmd))))))
+
+(ert-deftest claude-code-ide-test-build-remote-ssh-command-with-user ()
+  "Test SSH command includes user@host when user is specified."
+  (cl-letf (((symbol-function 'file-remote-p)
+             (lambda (path &optional id connected)
+               (when (string-prefix-p "/mock-ssh:myuser@host:" path)
+                 (cond
+                  ((eq id 'user) "myuser")
+                  ((eq id 'host) "myhost")
+                  (t "/mock-ssh:myuser@host:"))))))
+    (let ((claude-code-ide-tramp-ssh-extra-args ""))
+      (let ((cmd (claude-code-ide--build-remote-ssh-command
+                  "/mock-ssh:myuser@host:" 8800 12345 "/home/user/script.sh")))
+        (should (string-match-p "myuser@myhost" cmd))))))
+
+(ert-deftest claude-code-ide-test-build-remote-ssh-command-extra-args ()
+  "Test SSH command includes extra args when configured."
+  (cl-letf (((symbol-function 'file-remote-p)
+             (lambda (path &optional id connected)
+               (when (string-prefix-p "/mock-ssh:host:" path)
+                 (cond
+                  ((eq id 'user) nil)
+                  ((eq id 'host) "myhost")
+                  (t "/mock-ssh:host:"))))))
+    (let ((claude-code-ide-tramp-ssh-extra-args "-J bastion"))
+      (let ((cmd (claude-code-ide--build-remote-ssh-command
+                  "/mock-ssh:host:" 8800 12345 "/home/user/script.sh")))
+        (should (string-match-p "-J bastion" cmd))))))
+
+(ert-deftest claude-code-ide-test-get-workspace-folders-strips-tramp ()
+  "Test that getWorkspaceFolders strips TRAMP prefix."
+  (cl-letf (((symbol-function 'file-remote-p)
+             (lambda (path &optional id connected)
+               (when (string-prefix-p "/mock-ssh:host:" path)
+                 (when (eq id 'localname)
+                   (substring path (length "/mock-ssh:host:")))))))
+    (cl-letf (((symbol-function 'claude-code-ide-mcp--get-buffer-project)
+               (lambda () "/mock-ssh:host:/home/user/project/"))
+              ((symbol-function 'expand-file-name)
+               (lambda (path &optional dir)
+                 (if (string-prefix-p "/mock-ssh:host:" path) path
+                   (if dir (concat (directory-file-name dir) "/" path) path)))))
+      (let ((result (claude-code-ide-mcp-handle-get-workspace-folders nil)))
+        (let ((folders (alist-get 'folders result)))
+          (should (vectorp folders))
+          ;; Should contain plain remote path, not TRAMP path
+          (should (member "/home/user/project/" (append folders nil)))
+          ;; Should NOT contain TRAMP path
+          (should (not (member "/mock-ssh:host:/home/user/project/" (append folders nil)))))))))
+
+(ert-deftest claude-code-ide-test-mcp-session-has-remote-prefix-slot ()
+  "Test that MCP session struct has remote-prefix slot."
+  ;; Test local session
+  (let ((local-session (make-claude-code-ide-mcp-session
+                        :project-dir "/home/user/project/"
+                        :remote-prefix nil)))
+    (should (null (claude-code-ide-mcp-session-remote-prefix local-session))))
+  ;; Test remote session
+  (let ((remote-session (make-claude-code-ide-mcp-session
+                         :project-dir "/ssh:host:/home/user/project/"
+                         :remote-prefix "/ssh:host:")))
+    (should (equal (claude-code-ide-mcp-session-remote-prefix remote-session)
+                   "/ssh:host:"))))
+
 (provide 'claude-code-ide-tests)
 
 ;; Local Variables:

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -1929,13 +1929,16 @@ have completed before cleanup.  Waits up to 5 seconds."
               ((symbol-function 'ws-send-404)
                #'claude-code-ide-mcp-server-tests--mock-ws-send-404))
       ;; Test send-json-response
-      (claude-code-ide-mcp-http-server--send-json-response
-       mock-request 200 '((test . "data")))
+      ;; The function throws 'close-connection as part of web-server protocol
+      (catch 'close-connection
+        (claude-code-ide-mcp-http-server--send-json-response
+         mock-request 200 '((test . "data"))))
       (should (equal claude-code-ide-mcp-server-tests--last-response-status 200))
       (should (string-match "test.*:.*data" claude-code-ide-mcp-server-tests--last-response))
 
       ;; Test handle-get (404 response)
-      (claude-code-ide-mcp-http-server--handle-get mock-request)
+      (catch 'close-connection
+        (claude-code-ide-mcp-http-server--handle-get mock-request))
       (should (equal claude-code-ide-mcp-server-tests--last-response-status 404)))))
 
 ;;; MCP Server Session Context Tests

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -874,7 +874,7 @@ REMOTE-WORKING-DIR is the plain (non-TRAMP) project directory on the remote."
          (script-name (format "launch-%d.sh" (emacs-pid)))
          (script-plain (concat script-dir-plain "/" script-name))
          (script-tramp (claude-code-ide--tramp-add-prefix remote-prefix script-plain))
-         (script-content (format "#!/bin/bash\nexport CLAUDE_CODE_SSE_PORT=%d\nexport ENABLE_IDE_INTEGRATION=true\nexport TERM_PROGRAM=emacs\nexport FORCE_CODE_TERMINAL=true\ncd %s\nexec %s\n"
+         (script-content (format "#!/usr/bin/env bash\nexport CLAUDE_CODE_SSE_PORT=%d\nexport ENABLE_IDE_INTEGRATION=true\nexport TERM_PROGRAM=emacs\nexport FORCE_CODE_TERMINAL=true\ncd %s\nexec %s\n"
                                  ws-port
                                  (shell-quote-argument remote-working-dir)
                                  claude-cmd)))

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -118,6 +118,12 @@ This should be a string of space-separated flags, e.g. \"--model opus\"."
   :type 'string
   :group 'claude-code-ide)
 
+(defcustom claude-code-ide-tramp-ssh-extra-args ""
+  "Extra arguments passed to SSH for remote TRAMP sessions.
+Useful for jump hosts, custom keys, etc.  Example: \"-J bastion\"."
+  :type 'string
+  :group 'claude-code-ide)
+
 (defcustom claude-code-ide-system-prompt nil
   "System prompt to append to Claude's default system prompt.
 When non-nil, the --append-system-prompt flag will be added with this value.
@@ -581,6 +587,26 @@ width has actually changed, working around the scrolling glitch."
       (expand-file-name (project-root project))
     (expand-file-name default-directory)))
 
+;;; TRAMP Helper Functions
+
+(defun claude-code-ide--tramp-remote-p (path)
+  "Return TRAMP prefix if PATH is a remote SSH/SCP/RSYNC path, else nil."
+  (when (and path (file-remote-p path))
+    (when (member (file-remote-p path 'method) '("ssh" "scp" "rsync"))
+      (file-remote-p path))))
+
+(defun claude-code-ide--tramp-localname (path)
+  "Return local-on-remote portion of TRAMP PATH, or PATH if local."
+  (or (file-remote-p path 'localname) path))
+
+(defun claude-code-ide--tramp-add-prefix (remote-prefix plain-path)
+  "Prepend REMOTE-PREFIX (e.g. \"/ssh:host:\") to PLAIN-PATH."
+  (concat remote-prefix plain-path))
+
+(defun claude-code-ide--tramp-remote-home (remote-prefix)
+  "Return home directory path on remote host (plain path, no TRAMP prefix)."
+  (file-remote-p (expand-file-name "~" remote-prefix) 'localname))
+
 (defun claude-code-ide--get-buffer-name (&optional directory)
   "Get the buffer name for the Claude Code session in DIRECTORY.
 If DIRECTORY is not provided, use the current working directory."
@@ -837,6 +863,50 @@ and args is a list of arguments."
     (cons (car parts) (cdr parts))))
 
 
+(defun claude-code-ide--write-remote-launcher-script (remote-prefix ws-port claude-cmd remote-working-dir)
+  "Write a launcher script to the remote machine and return its plain path.
+REMOTE-PREFIX is the TRAMP prefix (e.g. \"/ssh:host:\").
+WS-PORT is the WebSocket port for CLAUDE_CODE_SSE_PORT.
+CLAUDE-CMD is the full claude command string (with flags).
+REMOTE-WORKING-DIR is the plain (non-TRAMP) project directory on the remote."
+  (let* ((remote-home (claude-code-ide--tramp-remote-home remote-prefix))
+         (script-dir-plain (concat remote-home "/.claude/ide"))
+         (script-name (format "launch-%d.sh" (emacs-pid)))
+         (script-plain (concat script-dir-plain "/" script-name))
+         (script-tramp (claude-code-ide--tramp-add-prefix remote-prefix script-plain))
+         (script-content (format "#!/bin/bash\nexport CLAUDE_CODE_SSE_PORT=%d\nexport ENABLE_IDE_INTEGRATION=true\nexport TERM_PROGRAM=emacs\nexport FORCE_CODE_TERMINAL=true\ncd %s\nexec %s\n"
+                                 ws-port
+                                 (shell-quote-argument remote-working-dir)
+                                 claude-cmd)))
+    (make-directory (claude-code-ide--tramp-add-prefix remote-prefix script-dir-plain) t)
+    (with-temp-file script-tramp
+      (insert script-content))
+    script-plain))
+
+(defun claude-code-ide--build-remote-ssh-command (remote-prefix ws-port http-port remote-script-plain)
+  "Build an SSH command that forwards ports and runs REMOTE-SCRIPT-PLAIN.
+REMOTE-PREFIX is the TRAMP prefix (e.g. \"/ssh:host:\").
+WS-PORT is the WebSocket port to forward.
+HTTP-PORT is the HTTP MCP tools server port to forward (may be nil).
+REMOTE-SCRIPT-PLAIN is the plain path to the launcher script on the remote host."
+  (let* ((user (file-remote-p remote-prefix 'user))
+         (host (file-remote-p remote-prefix 'host))
+         (user-at-host (if user (format "%s@%s" user host) host))
+         (extra-args (if (and claude-code-ide-tramp-ssh-extra-args
+                              (not (string-empty-p claude-code-ide-tramp-ssh-extra-args)))
+                         (concat " " claude-code-ide-tramp-ssh-extra-args)
+                       ""))
+         (http-forward (if http-port
+                           (format " -R %d:localhost:%d" http-port http-port)
+                         "")))
+    (format "ssh -R %d:localhost:%d%s%s %s -t 'bash %s; rm -f %s'"
+            ws-port ws-port
+            http-forward
+            extra-args
+            user-at-host
+            remote-script-plain
+            remote-script-plain)))
+
 (defun claude-code-ide--create-terminal-session (buffer-name working-dir port continue resume session-id)
   "Create a new terminal session for Claude Code.
 BUFFER-NAME is the name for the terminal buffer.
@@ -851,24 +921,45 @@ Signals an error if terminal fails to initialize."
   ;; Ensure terminal backend is available before proceeding
   (claude-code-ide--terminal-ensure-backend)
   (let* ((claude-cmd (claude-code-ide--build-claude-command continue resume session-id))
-         (default-directory working-dir)
-         (env-vars (list (format "CLAUDE_CODE_SSE_PORT=%d" port)
-                         "ENABLE_IDE_INTEGRATION=true"
-                         "TERM_PROGRAM=emacs"
-                         "FORCE_CODE_TERMINAL=true")))
+         ;; Determine if this is a remote TRAMP session
+         (remote-prefix (claude-code-ide--tramp-remote-p working-dir))
+         ;; For remote: run SSH locally; for local: run claude directly
+         (effective-cmd (if remote-prefix
+                            (let* ((remote-working-dir (claude-code-ide--tramp-localname working-dir))
+                                   (http-port (claude-code-ide-mcp-server-get-port))
+                                   (remote-script-plain
+                                    (claude-code-ide--write-remote-launcher-script
+                                     remote-prefix port claude-cmd remote-working-dir)))
+                              (claude-code-ide--build-remote-ssh-command
+                               remote-prefix port http-port remote-script-plain))
+                          claude-cmd))
+         ;; Remote: run terminal locally in home dir; local: use project dir
+         (default-directory (if remote-prefix
+                                (expand-file-name "~/")
+                              working-dir))
+         ;; Remote: env vars are set in the launcher script; local: pass them here
+         (env-vars (if remote-prefix
+                       nil
+                     (list (format "CLAUDE_CODE_SSE_PORT=%d" port)
+                           "ENABLE_IDE_INTEGRATION=true"
+                           "TERM_PROGRAM=emacs"
+                           "FORCE_CODE_TERMINAL=true"))))
     ;; Log the command for debugging
-    (claude-code-ide-debug "Starting Claude with command: %s" claude-cmd)
-    (claude-code-ide-debug "Working directory: %s" working-dir)
-    (claude-code-ide-debug "Environment: CLAUDE_CODE_SSE_PORT=%d" port)
+    (claude-code-ide-debug "Starting Claude with command: %s" effective-cmd)
+    (claude-code-ide-debug "Working directory: %s" default-directory)
+    (when (not remote-prefix)
+      (claude-code-ide-debug "Environment: CLAUDE_CODE_SSE_PORT=%d" port))
     (claude-code-ide-debug "Session ID: %s" session-id)
     (claude-code-ide-debug "Terminal backend: %s" claude-code-ide-terminal-backend)
+    (when remote-prefix
+      (claude-code-ide-debug "Remote TRAMP prefix: %s" remote-prefix))
 
     (cond
      ;; vterm backend
      ((eq claude-code-ide-terminal-backend 'vterm)
       (let* ((vterm-buffer-name buffer-name)
-             ;; Set vterm-shell to run Claude directly
-             (vterm-shell claude-cmd)
+             ;; Set vterm-shell to run effective command (SSH or claude)
+             (vterm-shell effective-cmd)
              ;; vterm uses vterm-environment for passing env vars
              (vterm-environment (append env-vars vterm-environment)))
         ;; Create vterm buffer without switching to it
@@ -894,7 +985,7 @@ Signals an error if terminal fails to initialize."
       (let* ((buffer (get-buffer-create buffer-name))
              (eat-term-name "xterm-256color")
              ;; Parse command string into program and args
-             (cmd-parts (claude-code-ide--parse-command-string claude-cmd))
+             (cmd-parts (claude-code-ide--parse-command-string effective-cmd))
              (program (car cmd-parts))
              (args (cdr cmd-parts)))
         (with-current-buffer buffer
@@ -929,9 +1020,6 @@ This function handles:
 - Existing session detection and window toggling
 - New session creation with MCP server setup
 - Process and buffer lifecycle management"
-  (unless (claude-code-ide--ensure-cli)
-    (user-error "Claude Code CLI not available.  Please install it and ensure it's in PATH"))
-
   ;; Clean up any dead processes first
   (claude-code-ide--cleanup-dead-processes)
 
@@ -945,6 +1033,10 @@ This function handles:
              (buffer-live-p existing-buffer)
              existing-process)
         (claude-code-ide--toggle-existing-window existing-buffer working-dir)
+      ;; Only verify local CLI for local sessions
+      (unless (claude-code-ide--tramp-remote-p working-dir)
+        (unless (claude-code-ide--ensure-cli)
+          (user-error "Claude Code CLI not available.  Please install it and ensure it's in PATH")))
       ;; Ensure the selected terminal backend is available before starting MCP
       (claude-code-ide--terminal-ensure-backend)
       ;; Start MCP server with project directory

--- a/record-claude-messages.sh
+++ b/record-claude-messages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to record WebSocket messages between VS Code and Claude Code
 # Uses websocat to create a proxy and log all messages

--- a/scripts/compile-and-test.sh
+++ b/scripts/compile-and-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Combined compile and test check for Claude Code IDE
 # This script is used by both GitHub Actions and Claude stop hooks

--- a/scripts/format-and-clean.sh
+++ b/scripts/format-and-clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Combined format and whitespace cleaning for Claude Code IDE
 # This avoids file conflicts when both hooks run simultaneously


### PR DESCRIPTION
## Summary

- **Remote Claude sessions**: when the current project is on a remote machine via TRAMP (`/ssh:host:/home/user/project/`), starts Claude on that machine via SSH with `-R` port-forwarding so it can reach Emacs's local MCP servers (both the WebSocket IDE server and the HTTP tools server)
- **Remote file operations**: all MCP handlers translate between Claude's view of paths (plain remote paths like `/home/user/file.py`) and Emacs's TRAMP paths (`/ssh:host:/home/user/file.py`)
- **Nix compatibility**: replaces `#!/bin/bash` with `#!/usr/bin/env bash` in all shell scripts including the generated remote launcher script

Only `ssh`/`scp`/`rsync` TRAMP methods are supported (they provide `-R` port forwarding). The remote machine must have `claude` CLI in PATH with key-based SSH auth.

### How it works

1. Emacs starts a **local** terminal running `ssh -R WS_PORT:localhost:WS_PORT -R HTTP_PORT:localhost:HTTP_PORT user@host -t 'bash ~/.claude/ide/launch-PID.sh; rm ...'`
2. The launcher script is written to the remote host via TRAMP before connecting — it sets env vars (`CLAUDE_CODE_SSE_PORT`, `ENABLE_IDE_INTEGRATION`, etc.) and execs the claude command with all flags. Writing to a file avoids shell quoting issues with `--mcp-config` JSON.
3. Claude on the remote sees `localhost:PORT` → SSH tunnel → local Emacs MCP servers
4. Lockfile is written on the remote machine (via TRAMP) so Claude can find the session
5. All paths returned to Claude are stripped of their TRAMP prefix; all paths received from Claude have the prefix added before Emacs uses them

### New API

- `claude-code-ide-tramp-ssh-extra-args` — defcustom for jump hosts, custom keys, etc.
- `claude-code-ide--tramp-remote-p` / `--tramp-localname` / `--tramp-add-prefix` / `--tramp-remote-home` — TRAMP helper utilities
- `claude-code-ide-mcp-session` gains a `remote-prefix` slot

## Test plan

- [ ] Run existing test suite: `emacs -batch -L . -l ert -l claude-code-ide-tests.el -f ert-run-tests-batch-and-exit` (85 tests, 78 pass, 7 skipped)
- [ ] 15 new tests cover TRAMP helpers, path resolution/stripping, session lookup, SSH command building, and workspace folder stripping
- [ ] Fixed `claude-code-ide-mcp-server-test-ws-send-fix`: the test was missing a `(catch 'close-connection ...)` wrapper around calls to `send-json-response` and `handle-get`, which unconditionally throw as part of the web-server request protocol
- [ ] Manual: visit a remote file via TRAMP, run `M-x claude-code-ide`, verify local terminal opens running SSH with `-R` flags
- [ ] Manual: ask Claude to open a file — should open via TRAMP in Emacs
- [ ] Manual: verify diagnostics, xref, and workspace folder responses use plain remote paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)