### PR TITLE
Fix orange border artifacts in README screenshots

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,27 +44,27 @@ This deep integration means Claude Code understands your project context and can
 
 *** Active File Awareness
 #+CAPTION: Claude Code automatically knows which file you're currently viewing in Emacs
-#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/25053b5f1b8123eed5c3f00e8b3e9687ee33391d/screenshots/file.png">
+#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/fb517ac3700f92f8d5481f0bcf9fe4a3c26c91ab/screenshots/file.png">
 #+html: <p align="center"><i>Claude Code automatically knows which file you're currently viewing in Emacs</i></p>
 
 *** Code Selection Context
 #+CAPTION: Claude Code can access and work with selected text in your buffers
-#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/25053b5f1b8123eed5c3f00e8b3e9687ee33391d/screenshots/selection.png">
+#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/fb517ac3700f92f8d5481f0bcf9fe4a3c26c91ab/screenshots/selection.png">
 #+html: <p align="center"><i>Claude Code can access and work with selected text in your buffers</i></p>
 
 *** Advanced Diff View with Diagnostics
 #+CAPTION: Integrated ediff view for code changes, with Claude Code able to directly access diagnostic data (errors, warnings, etc.) from opened files
-#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/25053b5f1b8123eed5c3f00e8b3e9687ee33391d/screenshots/ediff_diag.png">
+#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/fb517ac3700f92f8d5481f0bcf9fe4a3c26c91ab/screenshots/ediff_diag.png">
 #+html: <p align="center"><i>Integrated ediff view for code changes, with Claude Code able to directly access diagnostic data (errors, warnings, etc.) from opened files</i></p>
 
 *** Automatic Text Mentions
 #+CAPTION: Automatically mention and reference selected text in Claude conversations
-#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/25053b5f1b8123eed5c3f00e8b3e9687ee33391d/screenshots/mentions.png">
+#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/fb517ac3700f92f8d5481f0bcf9fe4a3c26c91ab/screenshots/mentions.png">
 #+html: <p align="center"><i>Automatically mention and reference selected text in Claude conversations</i></p>
 
 *** Session Restoration
 #+CAPTION: Resume previous Claude Code conversations with the --resume flag
-#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/25053b5f1b8123eed5c3f00e8b3e9687ee33391d/screenshots/restore.png">
+#+html: <img src="https://github.com/manzaltu/claude-code-ide.el/blob/fb517ac3700f92f8d5481f0bcf9fe4a3c26c91ab/screenshots/restore.png">
 #+html: <p align="center"><i>Resume previous Claude Code conversations with the --resume flag</i></p>
 
 * Installation


### PR DESCRIPTION
Update screenshot references to point to fixed images on the screenshots branch with window border pixels cropped out.