### PR TITLE
Add CLAUDE_CODE_NO_FLICKER support

### DIFF
--- a/README.org
+++ b/README.org
@@ -210,6 +210,7 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 | ~claude-code-ide-mcp-server-port~               | Port for MCP tools server                   | ~nil~ (auto-select)                    |
 | ~claude-code-ide-mcp-server-tools~              | Alist of exposed Emacs functions            | ~nil~                                  |
 | ~claude-code-ide-diagnostics-backend~           | Diagnostics backend (auto/flycheck/flymake) | ~'auto~                                |
+| ~claude-code-ide-no-flicker~                    | Enable flicker-free terminal renderer       | ~nil~                                  |
 | ~claude-code-ide-prevent-reflow-glitch~         | Prevent terminal reflow glitch (bug #1422)  | ~t~                                    |
 | ~claude-code-ide-enable-execute-code~           | Allow model to evaluate Elisp in Emacs      | ~t~                                    |
 
@@ -262,6 +263,19 @@ Claude Code IDE supports both =vterm= and =eat= as terminal backends. By default
 #+end_src
 
 The =eat= backend is a pure Elisp terminal emulator that may work better in some environments where =vterm= compilation is problematic. Both backends provide full terminal functionality including color support and special key handling.
+
+**** Flicker-Free Renderer (Experimental)
+
+Claude Code includes an experimental alternative terminal renderer that eliminates flickering. To enable it:
+
+#+begin_src emacs-lisp
+(setq claude-code-ide-no-flicker t)
+#+end_src
+
+Note that with this renderer, normal Emacs buffer scrolling and search (=C-s=, =C-r=) will not work in the terminal buffer. Instead, use Claude Code's built-in keybindings:
+
+- =C-o j= / =C-o k= - Scroll up/down through the transcript
+- =C-o /= - Search the transcript
 
 **** vterm Rendering Optimization
 

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -223,6 +223,13 @@ environments."
                  (const :tag "eat" eat))
   :group 'claude-code-ide)
 
+(defcustom claude-code-ide-no-flicker nil
+  "Enable Claude Code's flicker-free terminal renderer.
+When non-nil, sets CLAUDE_CODE_NO_FLICKER=1 which activates an
+alternative rendering mode that eliminates terminal flicker."
+  :type 'boolean
+  :group 'claude-code-ide)
+
 (defcustom claude-code-ide-prevent-reflow-glitch t
   "Workaround for Claude Code terminal scrolling bug #1422.
 When non-nil (default), prevents the terminal from reflowing on height-only
@@ -865,9 +872,11 @@ Signals an error if terminal fails to initialize."
   (claude-code-ide--terminal-ensure-backend)
   (let* ((claude-cmd (claude-code-ide--build-claude-command continue resume session-id))
          (default-directory working-dir)
-         (env-vars (list (format "CLAUDE_CODE_SSE_PORT=%d" port)
-                         "TERM_PROGRAM=emacs"
-                         "FORCE_CODE_TERMINAL=true")))
+         (env-vars (append (list (format "CLAUDE_CODE_SSE_PORT=%d" port)
+                                 "TERM_PROGRAM=emacs"
+                                 "FORCE_CODE_TERMINAL=true")
+                           (when claude-code-ide-no-flicker
+                             (list "CLAUDE_CODE_NO_FLICKER=1")))))
     ;; Log the command for debugging
     (claude-code-ide-debug "Starting Claude with command: %s" claude-cmd)
     (claude-code-ide-debug "Working directory: %s" working-dir)


### PR DESCRIPTION
Add claude-code-ide-no-flicker option that passes
CLAUDE_CODE_NO_FLICKER=1 to the CLI process, enabling the experimental flicker-free terminal renderer. Defaults to nil.