### PR TITLE
feat(prompt): Add prompt buffer editor for Claude terminal

### DIFF
--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -499,6 +499,10 @@ have completed before cleanup.  Waits up to 5 seconds."
               (should (eq major-mode 'text-mode))
               (should (equal (buffer-string) "existing input"))
               (should (equal claude-code-ide--session-buffer test-buffer))
+              (should (eq (local-key-binding (kbd "C-c C-c"))
+                          #'claude-code-ide--apply-prompt-buffer))
+              (should (eq (local-key-binding (kbd "C-c C-k"))
+                          #'claude-code-ide--cancel-prompt-buffer))
 
               ;; Simulate editing the prompt
               (erase-buffer)
@@ -626,6 +630,23 @@ have completed before cleanup.  Waits up to 5 seconds."
         (claude-code-ide--apply-prompt-buffer)))
     (should (eq restored-config saved-config))
     (should (equal sent-string "updated input"))))
+
+(ert-deftest claude-code-ide-test-apply-empty-prompt-buffer-clears-terminal ()
+  "Test applying an empty prompt buffer still clears the terminal prompt."
+  (let ((sent-prompt :unset)
+        (sent-no-return nil)
+        (sent-clear-line nil))
+    (with-temp-buffer
+      (setq-local claude-code-ide--session-buffer (get-buffer-create "*Claude Prompt Session*"))
+      (cl-letf (((symbol-function 'claude-code-ide-send-prompt)
+                 (lambda (prompt &optional no-return clear-line)
+                   (setq sent-prompt prompt
+                         sent-no-return no-return
+                         sent-clear-line clear-line))))
+        (claude-code-ide--apply-prompt-buffer)))
+    (should (equal sent-prompt ""))
+    (should sent-no-return)
+    (should sent-clear-line)))
 
 (ert-deftest claude-code-ide-test-cancel-prompt-buffer-restores-window-configuration ()
   "Test cancelling the prompt buffer restores the saved window configuration."
@@ -768,14 +789,14 @@ have completed before cleanup.  Waits up to 5 seconds."
   (with-temp-buffer
     (let ((claude-code-ide-terminal-backend 'vterm))
       (claude-code-ide--setup-terminal-keybindings)
-      (should (eq (local-key-binding (kbd "C-'"))
+      (should (eq (local-key-binding (kbd "C-c '"))
                   #'claude-code-ide-edit-prompt))
       (should (eq (local-key-binding (kbd "C-<escape>"))
                   #'claude-code-ide-send-escape))))
   (with-temp-buffer
     (let ((claude-code-ide-terminal-backend 'eat))
       (claude-code-ide--setup-terminal-keybindings)
-      (should (eq (local-key-binding (kbd "C-'"))
+      (should (eq (local-key-binding (kbd "C-c '"))
                   #'claude-code-ide-edit-prompt))
       (should (eq (local-key-binding (kbd "C-<escape>"))
                   #'claude-code-ide-send-escape)))))

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -467,6 +467,258 @@ have completed before cleanup.  Waits up to 5 seconds."
           (should (null sent-string))
           (should (null sent-return)))))))
 
+(ert-deftest claude-code-ide-test-edit-prompt-command ()
+  "Test the `claude-code-ide-edit-prompt' command."
+  (let* ((working-dir (expand-file-name "/tmp/test-project"))
+         (buffer-name "*Claude Code [test-project]*")
+         (test-buffer (get-buffer-create buffer-name))
+         (sent-string nil)
+         (sent-no-return nil)
+         (sent-clear-line nil))
+    (unwind-protect
+        (cl-letf* (((symbol-function 'claude-code-ide--get-working-directory)
+                    (lambda () working-dir))
+                   ((symbol-function 'claude-code-ide--get-buffer-name)
+                    (lambda () buffer-name))
+                   ((symbol-function 'claude-code-ide--get-terminal-input)
+                    (lambda (_) "existing input"))
+                   ((symbol-function 'claude-code-ide-send-prompt)
+                    (lambda (prompt &optional no-return clear-line)
+                      (setq sent-string prompt
+                            sent-no-return no-return
+                            sent-clear-line clear-line)))
+                   ((symbol-function 'pop-to-buffer) #'ignore)
+                   ((symbol-function 'display-buffer) #'ignore))
+          ;; Call the command
+          (claude-code-ide-edit-prompt)
+
+          ;; Verify prompt buffer was created and initialized
+          (let ((prompt-buf (get-buffer "*Claude Prompt [test-project]*")))
+            (should prompt-buf)
+            (with-current-buffer prompt-buf
+              (should (eq major-mode 'text-mode))
+              (should (equal (buffer-string) "existing input"))
+              (should (equal claude-code-ide--session-buffer test-buffer))
+
+              ;; Simulate editing the prompt
+              (erase-buffer)
+              (insert "updated input")
+
+              ;; Simulate finishing
+              (claude-code-ide--apply-prompt-buffer))
+
+            ;; Verify prompt was sent correctly (overwrite, no return)
+            (should (equal sent-string "updated input"))
+            (should sent-no-return)
+            (should sent-clear-line)
+            ;; Verify prompt buffer was killed
+            (should-not (buffer-live-p prompt-buf)))
+
+            ;; Test with active region
+            (with-temp-buffer
+            (insert "region content")
+            (set-mark (point-min))
+            (goto-char (point-max))
+            (activate-mark)
+            (should (use-region-p))
+            (claude-code-ide-edit-prompt)
+            (let ((prompt-buf (get-buffer (format "*Claude Prompt [%s]*"
+                                                  (file-name-nondirectory (directory-file-name working-dir))))))
+              (should prompt-buf)
+              (with-current-buffer prompt-buf
+                (should (equal (buffer-string) "region content"))
+                (kill-buffer))))
+
+            ;; Test cancellation
+            (claude-code-ide-edit-prompt)
+
+          (let ((prompt-buf (get-buffer "*Claude Prompt [test-project]*")))
+            (should prompt-buf)
+            (with-current-buffer prompt-buf
+              (claude-code-ide--cancel-prompt-buffer))
+            (should-not (buffer-live-p prompt-buf))))
+      ;; Cleanup
+      (when (buffer-live-p test-buffer)
+        (kill-buffer test-buffer)))))
+
+(ert-deftest claude-code-ide-test-get-terminal-input ()
+  "Test grabbing and stripping the Claude Code terminal prompt."
+  (with-temp-buffer
+    ;; Test standard prompt
+    (erase-buffer)
+    (insert "claude > my input")
+    (should (equal (claude-code-ide--get-terminal-input (current-buffer)) "my input"))
+    
+    ;; Test prompt with trailing spaces/newlines
+    (erase-buffer)
+    (insert "claude > my input  \n\n")
+    (should (equal (claude-code-ide--get-terminal-input (current-buffer)) "my input"))
+    
+    ;; Test prompt with complex prefix
+    (erase-buffer)
+    (insert "╭─...─╮\n│ claude > my input")
+    (should (equal (claude-code-ide--get-terminal-input (current-buffer)) "my input"))
+    
+    ;; Test finding last prompt in buffer
+    (erase-buffer)
+    (insert "previous output\nclaude > current input")
+    (should (equal (claude-code-ide--get-terminal-input (current-buffer)) "current input"))
+    
+    ;; Test simple prompt
+    (erase-buffer)
+    (insert "> simple input")
+    (should (equal (claude-code-ide--get-terminal-input (current-buffer)) "simple input"))))
+
+(ert-deftest claude-code-ide-test-get-terminal-input-vterm-metadata ()
+  "Test grabbing terminal input from vterm prompt and cursor positions."
+  (with-temp-buffer
+    (insert "old output\n> live input")
+    (let ((prompt-end (save-excursion
+                        (goto-char (point-min))
+                        (search-forward "> ")))
+          (cursor (point-max)))
+      (cl-letf (((symbol-function 'derived-mode-p)
+                 (lambda (&rest modes) (memq 'vterm-mode modes)))
+                ((symbol-function 'vterm-reset-cursor-point) #'ignore)
+                ((symbol-function 'vterm--get-prompt-point)
+                 (lambda () prompt-end))
+                ((symbol-function 'vterm--get-cursor-point)
+                 (lambda () cursor)))
+      (should (equal (claude-code-ide--get-terminal-input (current-buffer))
+                     "live input"))))))
+
+(ert-deftest claude-code-ide-test-get-terminal-input-eat-metadata ()
+  "Test grabbing terminal input from Eat's active input region."
+  (with-temp-buffer
+    (insert "previous output\n> pending input")
+    (let ((eat-terminal 'mock-terminal)
+          (input-start (save-excursion
+                         (goto-char (point-min))
+                         (search-forward "\n"))))
+      (cl-letf (((symbol-function 'derived-mode-p)
+                 (lambda (&rest modes) (memq 'eat-mode modes)))
+                ((symbol-function 'eat-term-end)
+                 (lambda (_terminal) input-start)))
+        (should (equal (claude-code-ide--get-terminal-input (current-buffer))
+                       "pending input"))))))
+
+(ert-deftest claude-code-ide-test-strip-terminal-prompt-prefix-decorative-glyph ()
+  "Test stripping decorative shell prompt glyphs from captured input."
+  (should (equal (claude-code-ide--strip-terminal-prompt-prefix "❯\u00a0ihe some thing it ")
+                 "ihe some thing it "))
+  (should (equal (claude-code-ide--strip-terminal-prompt-prefix "$ test")
+                 "test")))
+
+(ert-deftest claude-code-ide-test-apply-prompt-buffer-restores-window-configuration ()
+  "Test finishing the prompt buffer restores the saved window configuration."
+  (let ((saved-config (current-window-configuration))
+        (restored-config nil)
+        (sent-string nil))
+    (with-temp-buffer
+      (setq-local claude-code-ide--session-buffer (get-buffer-create "*Claude Prompt Session*"))
+      (setq-local claude-code-ide--saved-window-configuration saved-config)
+      (insert "updated input")
+      (cl-letf (((symbol-function 'set-window-configuration)
+                 (lambda (config) (setq restored-config config)))
+                ((symbol-function 'claude-code-ide-send-prompt)
+                 (lambda (prompt &optional _no-return _clear-line)
+                   (setq sent-string prompt))))
+        (claude-code-ide--apply-prompt-buffer)))
+    (should (eq restored-config saved-config))
+    (should (equal sent-string "updated input"))))
+
+(ert-deftest claude-code-ide-test-cancel-prompt-buffer-restores-window-configuration ()
+  "Test cancelling the prompt buffer restores the saved window configuration."
+  (let ((saved-config (current-window-configuration))
+        (restored-config nil))
+    (with-temp-buffer
+      (setq-local claude-code-ide--saved-window-configuration saved-config)
+      (cl-letf (((symbol-function 'set-window-configuration)
+                 (lambda (config) (setq restored-config config))))
+        (claude-code-ide--cancel-prompt-buffer)))
+    (should (eq restored-config saved-config))))
+
+(ert-deftest claude-code-ide-test-at-mentioned-completion ()
+  "Test @ completion in the prompt buffer."
+  (let* ((working-dir (expand-file-name "/tmp/test-project"))
+         (mock-project (list 'project working-dir))
+         (mock-files (list (expand-file-name "file1.txt" working-dir)
+                           (expand-file-name "dir/file2.py" working-dir))))
+    (with-temp-buffer
+      (setq-local default-directory working-dir)
+      (cl-letf* (((symbol-function 'project-current) (lambda (&rest _) mock-project))
+                 ((symbol-function 'project-files) (lambda (&rest _) mock-files)))
+        
+        ;; Test completion at @
+        (erase-buffer)
+        (insert "@")
+        (let ((result (claude-code-ide--at-mentioned-completion-at-point)))
+          (should result)
+          (should (equal (nth 0 result) 2)) ; One after @
+          (should (equal (nth 1 result) 2))
+          (should (equal (try-completion "" (nth 2 result)) ""))
+          (should (equal (test-completion "file1.txt" (nth 2 result)) t))
+          (should (equal (test-completion "dir/file2.py" (nth 2 result)) t)))
+        
+        ;; Test completion with prefix
+        (erase-buffer)
+        (insert "Some text @f")
+        (let ((result (claude-code-ide--at-mentioned-completion-at-point)))
+          (should result)
+          (should (equal (nth 0 result) 12)) ; One after @
+          (should (equal (nth 1 result) 13))
+          (should (equal (test-completion "file1.txt" (nth 2 result)) t)))
+        
+        ;; Test no completion without @
+        (erase-buffer)
+        (insert "Just some text")
+        (should-not (claude-code-ide--at-mentioned-completion-at-point))))))
+
+(ert-deftest claude-code-ide-test-at-mentioned-completion-home-path ()
+  "Test @ completion switches to filesystem completion for ~/ paths."
+  (with-temp-buffer
+    (insert "@~/Do")
+    (let ((result (claude-code-ide--at-mentioned-completion-at-point))
+          (called-with nil))
+      (should result)
+      (cl-letf (((symbol-function 'completion-file-name-table)
+                 (lambda (string pred action)
+                   (setq called-with (list string pred action))
+                   (complete-with-action action '("~/Documents/" "~/Downloads/") string pred))))
+        (should (equal (try-completion "~/Do" (nth 2 result)) "~/Do"))
+        (should (equal (all-completions "~/Do" (nth 2 result))
+                       '("~/Documents/" "~/Downloads/"))))
+      (should (equal (car called-with) "~/Do")))))
+
+(ert-deftest claude-code-ide-test-filesystem-path-mention-p ()
+  "Test filesystem path mention detection."
+  (should (claude-code-ide--filesystem-path-mention-p "~/src"))
+  (should (claude-code-ide--filesystem-path-mention-p "/tmp"))
+  (should (claude-code-ide--filesystem-path-mention-p "./foo"))
+  (should (claude-code-ide--filesystem-path-mention-p "../foo"))
+  (should-not (claude-code-ide--filesystem-path-mention-p "foo/bar")))
+
+(ert-deftest claude-code-ide-test-at-mentioned-bounds ()
+  "Test @ mention bounds detection."
+  (with-temp-buffer
+    (insert "before @dir/file after")
+    (goto-char 17)
+    (should (equal (claude-code-ide--at-mentioned-bounds) '(9 . 17)))
+    (goto-char (point-max))
+    (should-not (claude-code-ide--at-mentioned-bounds))))
+
+(ert-deftest claude-code-ide-test-prompt-buffer-post-self-insert-triggers-completion ()
+  "Test @ mention typing triggers completion."
+  (with-temp-buffer
+    (insert "@f")
+    (let ((this-command 'self-insert-command)
+          (last-command-event ?f)
+          (called nil))
+      (cl-letf (((symbol-function 'completion-at-point)
+                 (lambda () (setq called t))))
+        (claude-code-ide--prompt-buffer-post-self-insert))
+      (should called))))
+
 (ert-deftest claude-code-ide-test-terminal-session-creation ()
   "Test terminal session creation with both backends."
   (let ((mock-vterm-buffer nil)
@@ -510,6 +762,23 @@ have completed before cleanup.  Waits up to 5 seconds."
             (should (bufferp (car result)))
             (should (processp (cdr result)))
             (should (bufferp mock-eat-buffer))))))))
+
+(ert-deftest claude-code-ide-test-setup-terminal-keybindings ()
+  "Test terminal keybindings include prompt buffer binding."
+  (with-temp-buffer
+    (let ((claude-code-ide-terminal-backend 'vterm))
+      (claude-code-ide--setup-terminal-keybindings)
+      (should (eq (local-key-binding (kbd "C-'"))
+                  #'claude-code-ide-edit-prompt))
+      (should (eq (local-key-binding (kbd "C-<escape>"))
+                  #'claude-code-ide-send-escape))))
+  (with-temp-buffer
+    (let ((claude-code-ide-terminal-backend 'eat))
+      (claude-code-ide--setup-terminal-keybindings)
+      (should (eq (local-key-binding (kbd "C-'"))
+                  #'claude-code-ide-edit-prompt))
+      (should (eq (local-key-binding (kbd "C-<escape>"))
+                  #'claude-code-ide-send-escape)))))
 
 (ert-deftest claude-code-ide-test-vterm-smart-renderer-passthrough ()
   "Test that vterm smart renderer passes through normal text immediately."

--- a/claude-code-ide-transient.el
+++ b/claude-code-ide-transient.el
@@ -39,6 +39,7 @@
 (declare-function claude-code-ide-switch-to-buffer "claude-code-ide" ())
 (declare-function claude-code-ide-insert-at-mentioned "claude-code-ide" ())
 (declare-function claude-code-ide-send-prompt "claude-code-ide" ())
+(declare-function claude-code-ide-edit-prompt "claude-code-ide" ())
 (declare-function claude-code-ide-send-escape "claude-code-ide" ())
 (declare-function claude-code-ide-insert-newline "claude-code-ide" ())
 (declare-function claude-code-ide-toggle "claude-code-ide" ())
@@ -330,6 +331,7 @@ Otherwise, if multiple sessions exist, prompt for selection."
    ["Interaction"
     ("i" "Insert selection" claude-code-ide-insert-at-mentioned)
     ("p" "Send prompt from minibuffer" claude-code-ide-send-prompt)
+    ("P" "Edit prompt in buffer" claude-code-ide-edit-prompt)
     ("e" "Send escape key" claude-code-ide-send-escape)
     ("n" "Insert newline" claude-code-ide-insert-newline)]
    ["Submenus"

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -4,7 +4,7 @@
 
 ;; Author: Yoav Orot
 ;; Version: 0.2.7
-;; Package-Requires: ((emacs "28.1") (websocket "1.12") (transient "0.9.0") (web-server "0.1.2"))
+;; Package-Requires: ((emacs "28.1") (websocket "1.12") (transient "0.9.0") (web-server "0.1.2") (with-editor "3.4.0"))
 ;; Keywords: ai, claude, code, assistant, mcp, websocket
 ;; URL: https://github.com/manzaltu/claude-code-ide.el
 
@@ -67,6 +67,15 @@
 (require 'claude-code-ide-emacs-tools)
 
 ;; External variable declarations
+(defvar with-editor-show-usage)
+(defvar with-editor-finish-query-functions)
+
+;; External function declarations for with-editor
+(declare-function with-editor-mode "with-editor" (&optional arg))
+(declare-function with-editor-finish "with-editor" ())
+(declare-function with-editor-cancel "with-editor" ())
+
+;; External variable declarations
 (defvar eat-terminal)
 (defvar eat--synchronize-scroll-function)
 (defvar vterm-shell)
@@ -79,11 +88,15 @@
 (declare-function vterm-send-string "vterm" (string))
 (declare-function vterm-send-escape "vterm" ())
 (declare-function vterm-send-return "vterm" ())
+(declare-function vterm-reset-cursor-point "vterm" ())
+(declare-function vterm--get-cursor-point "vterm" ())
+(declare-function vterm--get-prompt-point "vterm" ())
 (declare-function vterm--window-adjust-process-window-size "vterm" (&optional frame))
 
 ;; External function declarations for eat
 (declare-function eat-mode "eat" ())
 (declare-function eat-exec "eat" (buffer name command startfile &rest switches))
+(declare-function eat-term-end "eat" (terminal))
 (declare-function eat-term-send-string "eat" (terminal string))
 (declare-function eat-term-display-cursor "eat" (terminal))
 (declare-function eat--adjust-process-window-size "eat" (process windows))
@@ -398,6 +411,15 @@ INPUT contains the terminal output stream."
 (defvar-local claude-code-ide--saved-cursor-type nil
   "Saved cursor-type before entering vterm-copy-mode.")
 
+(defvar-local claude-code-ide--session-buffer nil
+  "The Claude Code session buffer associated with this prompt buffer.")
+
+(defvar-local claude-code-ide--saved-window-configuration nil
+  "Window configuration to restore when closing a prompt buffer.")
+
+(defvar-local claude-code-ide--at-mention-files-cache nil
+  "Cached relative file list for @ mention completion in the prompt buffer.")
+
 (defun claude-code-ide--vterm-copy-mode-hook ()
   "Make sure cursor is visible in `vterm-copy-mode'.
 Saves the current cursor-type when entering copy mode and restores it
@@ -511,17 +533,20 @@ from the window where it was initially created."
   "Set up keybindings for the Claude Code terminal buffer.
 This function binds:
 - M-RET (Alt-Return) to insert a newline
-- C-<escape> to send escape"
+- C-<escape> to send escape
+- C-' to open the prompt buffer"
   (cond
    ((eq claude-code-ide-terminal-backend 'vterm)
     ;; For vterm, we set up local keybindings in vterm-mode-map
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
-    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
+    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape)
+    (local-set-key (kbd "C-'") #'claude-code-ide-edit-prompt))
    ((eq claude-code-ide-terminal-backend 'eat)
     ;; For eat, we need to modify the semi-char mode map which is the default
     ;; We use local-set-key to make it buffer-local
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
-    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
+    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape)
+    (local-set-key (kbd "C-'") #'claude-code-ide-edit-prompt))
    (t
     (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))
 
@@ -1178,22 +1203,232 @@ Use this to balance between visual smoothness and raw responsiveness."
              "disabled (direct rendering, maximum responsiveness)")))
 
 ;;;###autoload
-(defun claude-code-ide-send-prompt (&optional prompt)
+(defun claude-code-ide-send-prompt (&optional prompt no-return clear-line)
   "Send a prompt to the Claude Code terminal.
 When called interactively, reads a prompt from the minibuffer.
-When called programmatically, sends the given PROMPT string."
+When called programmatically, sends the given PROMPT string.
+If NO-RETURN is non-nil, do not send the return key.
+If CLEAR-LINE is non-nil, send C-u to clear the current line first."
   (interactive)
   (let ((buffer-name (claude-code-ide--get-buffer-name)))
     (if-let ((buffer (get-buffer buffer-name)))
         (let ((prompt-to-send (or prompt (read-string "Claude prompt: "))))
           (when (not (string-empty-p prompt-to-send))
             (with-current-buffer buffer
+              (when clear-line
+                (if (eq claude-code-ide-terminal-backend 'vterm)
+                    (vterm-send-key "u" nil nil t) ; C-u
+                  (claude-code-ide--terminal-send-string "\C-u"))
+                ;; Give the terminal a moment to process the clear command
+                (sit-for 0.1))
               (claude-code-ide--terminal-send-string prompt-to-send)
-              ;; Small delay to ensure prompt text is processed before sending return
-              (sit-for 0.1)
-              (claude-code-ide--terminal-send-return))
+              (unless no-return
+                ;; Small delay to ensure prompt text is processed before sending return
+                (sit-for 0.1)
+                (claude-code-ide--terminal-send-return)))
             (claude-code-ide-debug "Sent prompt to Claude Code: %s" prompt-to-send)))
       (user-error "No Claude Code session for this project"))))
+
+;;;###autoload
+(defun claude-code-ide-edit-prompt ()
+  "Edit the Claude Code terminal prompt in a buffer.
+The buffer is in `text-mode` and `with-editor-mode` (if available).
+The buffer is initialized with the active region (if any) or the current terminal input.
+Press C-c C-c to update the terminal prompt (without sending) or C-c C-k to cancel."
+  (interactive)
+  (let* ((working-dir (claude-code-ide--get-working-directory))
+         (buffer-name (claude-code-ide--get-buffer-name))
+         (target-buffer (get-buffer buffer-name))
+         (window-config (current-window-configuration))
+         (region-text (when (use-region-p)
+                        (buffer-substring-no-properties (region-beginning) (region-end)))))
+    (unless target-buffer
+      (user-error "No Claude Code session for this project"))
+    (let ((prompt-buffer (get-buffer-create (format "*Claude Prompt [%s]*"
+                                                     (file-name-nondirectory (directory-file-name working-dir)))))
+          (initial-input (or region-text
+                             (claude-code-ide--get-terminal-input target-buffer))))
+      (with-current-buffer prompt-buffer
+        (text-mode)
+        (setq-local default-directory working-dir)
+        (setq-local claude-code-ide--session-buffer target-buffer)
+        (setq-local claude-code-ide--saved-window-configuration window-config)
+        (setq-local completion-styles '(flex partial-completion basic))
+        (setq-local completion-category-defaults nil)
+        (setq-local completion-category-overrides '((file (styles flex partial-completion basic))))
+        (setq-local tab-always-indent 'complete)
+        (add-hook 'completion-at-point-functions #'claude-code-ide--at-mentioned-completion-at-point nil t)
+        (add-hook 'post-self-insert-hook #'claude-code-ide--prompt-buffer-post-self-insert nil t)
+        (erase-buffer)
+        (when (and initial-input (not (string-empty-p initial-input)))
+          (insert (string-trim initial-input)))
+        (if (fboundp 'with-editor-mode)
+            (progn
+              (with-editor-mode 1)
+              (setq-local with-editor-show-usage nil)
+              (setq-local with-editor-finish-query-functions nil)
+              (add-hook 'with-editor-finish-hook 'claude-code-ide--apply-prompt-buffer nil t)
+              (add-hook 'with-editor-cancel-hook 'claude-code-ide--cancel-prompt-buffer nil t))
+          ;; Fallback if with-editor is not installed
+          (use-local-map (copy-keymap text-mode-map))
+          (local-set-key (kbd "C-c C-c") 'claude-code-ide--apply-prompt-buffer)
+          (local-set-key (kbd "C-c C-k") 'claude-code-ide--cancel-prompt-buffer))
+        (message "Type your prompt and press C-c C-c to update, or C-c C-k to cancel."))
+      (pop-to-buffer prompt-buffer))))
+
+(defun claude-code-ide--apply-prompt-buffer ()
+  "Apply current prompt buffer content to the Claude terminal and clean up."
+  (interactive)
+  (let ((prompt-buffer (current-buffer))
+        (prompt (buffer-substring-no-properties (point-min) (point-max)))
+        (target-buffer claude-code-ide--session-buffer)
+        (window-config claude-code-ide--saved-window-configuration))
+    (set-buffer-modified-p nil)
+    (when window-config
+      (set-window-configuration window-config))
+    (when (buffer-live-p prompt-buffer)
+      (kill-buffer prompt-buffer))
+    (when (and target-buffer (buffer-live-p target-buffer) (not (string-empty-p (string-trim prompt))))
+      ;; Send with no-return=t and clear-line=t to overwrite the existing prompt
+      (claude-code-ide-send-prompt (string-trim prompt) t t))))
+
+(defun claude-code-ide--get-terminal-input (buffer)
+  "Try to get the current input line from the Claude terminal in BUFFER."
+  (when (and buffer (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (when-let ((input
+                  (or (claude-code-ide--get-terminal-input-from-vterm)
+                      (claude-code-ide--get-terminal-input-from-eat)
+                      (claude-code-ide--get-terminal-input-from-text))))
+        (claude-code-ide--strip-terminal-prompt-prefix input)))))
+
+(defun claude-code-ide--strip-terminal-prompt-prefix (input)
+  "Strip a visible Claude prompt prefix from INPUT."
+  (let ((stripped (string-trim-left input "[[:space:]\u00a0]+")))
+    (cond
+     ((string-match "\\`[│┃[:space:]\u00a0]*\\(?:claude[[:space:]\u00a0]+\\)?>[[:space:]\u00a0]+" stripped)
+      (substring stripped (match-end 0)))
+     ;; Strip decorative shell prompts like \"❯ \" or \"$ \" when they are
+     ;; a short symbol-only token followed by whitespace.
+     ((string-match "\\`[[:space:]\u00a0]*[^[:alnum:]_[:space:]\u00a0]\\{1,3\\}[[:space:]\u00a0]+" stripped)
+      (substring stripped (match-end 0)))
+     (t stripped))))
+
+(defun claude-code-ide--get-terminal-input-from-vterm ()
+  "Read the active command buffer contents from the current vterm buffer."
+  (when (and (derived-mode-p 'vterm-mode)
+             (fboundp 'vterm--get-prompt-point)
+             (fboundp 'vterm--get-cursor-point))
+    (save-excursion
+      (when (fboundp 'vterm-reset-cursor-point)
+        (vterm-reset-cursor-point))
+      (let ((prompt-start (vterm--get-prompt-point))
+            (cursor (vterm--get-cursor-point)))
+        (when (and (integer-or-marker-p prompt-start)
+                   (integer-or-marker-p cursor)
+                   (<= prompt-start cursor))
+          (buffer-substring-no-properties prompt-start cursor))))))
+
+(defun claude-code-ide--get-terminal-input-from-eat ()
+  "Read the active command buffer contents from the current Eat buffer."
+  (when (and (derived-mode-p 'eat-mode)
+             (boundp 'eat-terminal)
+             eat-terminal
+             (fboundp 'eat-term-end))
+    (let ((input-start (eat-term-end eat-terminal))
+          (input-end (point-max)))
+      (when (and (integer-or-marker-p input-start)
+                 (integer-or-marker-p input-end)
+                 (<= input-start input-end))
+        (buffer-substring-no-properties input-start input-end)))))
+
+(defun claude-code-ide--get-terminal-input-from-text ()
+  "Fallback text-based extraction for terminal buffers without prompt metadata."
+  (save-excursion
+    (goto-char (point-max))
+    ;; Skip any trailing whitespace/newlines
+    (skip-chars-backward " \t\n\r")
+    (let ((end (point)))
+      (forward-line 0)
+      (let ((line (buffer-substring-no-properties (point) end)))
+        ;; Try to strip the prompt.
+        ;; Claude Code prompt usually looks like "╭─...─╮\n│ claude > my input" or just "claude > "
+        (cond
+         ((string-match "claude > \\(.*\\)" line)
+          (match-string 1 line))
+         ((string-match "> \\(.*\\)" line)
+          (match-string 1 line))
+         ;; If no prompt match on the last line, it might be a multi-line input.
+         ;; Let's try to find the last prompt in the buffer.
+         (t
+          (if (save-excursion
+                (re-search-backward "\\(?:claude \\)?> " nil t))
+              (buffer-substring-no-properties (match-end 0) end)
+            ;; Last resort: just return the current line
+            line)))))))
+
+(defun claude-code-ide--cancel-prompt-buffer ()
+  "Cancel the prompt and kill the buffer."
+  (interactive)
+  (let ((prompt-buffer (current-buffer))
+        (window-config claude-code-ide--saved-window-configuration))
+    (set-buffer-modified-p nil)
+    (when window-config
+      (set-window-configuration window-config))
+    (when (buffer-live-p prompt-buffer)
+      (kill-buffer prompt-buffer))))
+
+(defun claude-code-ide--at-mentioned-bounds ()
+  "Return bounds of the @ mention at point as (START . END)."
+  (let* ((pos (point))
+         (start (save-excursion
+                  (skip-chars-backward "^ \t\n\r")
+                  (point))))
+    (when (and (< start pos)
+               (char-equal (char-after start) ?@))
+      (cons (1+ start) pos))))
+
+(defun claude-code-ide--at-mention-candidates ()
+  "Return cached relative file paths for @ mention completion."
+  (or claude-code-ide--at-mention-files-cache
+      (setq claude-code-ide--at-mention-files-cache
+            (let* ((working-dir default-directory)
+                   (project (project-current nil working-dir))
+                   (files (if project
+                              (project-files project)
+                            (directory-files-recursively working-dir ".*" nil))))
+              (mapcar (lambda (f) (file-relative-name f working-dir)) files)))))
+
+(defun claude-code-ide--filesystem-path-mention-p (input)
+  "Return non-nil when INPUT should use filesystem path completion."
+  (or (string-prefix-p "~" input)
+      (file-name-absolute-p input)
+      (string-prefix-p "./" input)
+      (string-prefix-p "../" input)))
+
+(defun claude-code-ide--at-mention-completion-table (string pred action)
+  "Completion table for @ mentions using STRING, PRED, and ACTION."
+  (if (claude-code-ide--filesystem-path-mention-p string)
+      (completion-file-name-table string pred action)
+    (complete-with-action action (claude-code-ide--at-mention-candidates) string pred)))
+
+(defun claude-code-ide--at-mentioned-completion-at-point ()
+  "Completion at point for '@' mentions in the prompt buffer."
+  (when-let ((bounds (claude-code-ide--at-mentioned-bounds)))
+    (list (car bounds) (cdr bounds) #'claude-code-ide--at-mention-completion-table
+          :exclusive 'no
+          :annotation-function (lambda (_) " [File]")
+          :category 'file)))
+
+(defun claude-code-ide--prompt-buffer-post-self-insert ()
+  "Trigger fuzzy @ mention completion after typing in the prompt buffer."
+  (when (and (not (minibufferp))
+             (memq this-command '(self-insert-command org-self-insert-command))
+             (claude-code-ide--at-mentioned-bounds)
+             (let ((char last-command-event))
+               (and (characterp char)
+                    (not (memq char '(?\s ?\t ?\n ?\r))))))
+    (completion-at-point)))
 
 ;;;###autoload
 (defun claude-code-ide-toggle ()

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -534,19 +534,19 @@ from the window where it was initially created."
 This function binds:
 - M-RET (Alt-Return) to insert a newline
 - C-<escape> to send escape
-- C-' to open the prompt buffer"
+- C-c ' to open the prompt buffer"
   (cond
    ((eq claude-code-ide-terminal-backend 'vterm)
     ;; For vterm, we set up local keybindings in vterm-mode-map
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
     (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape)
-    (local-set-key (kbd "C-'") #'claude-code-ide-edit-prompt))
+    (local-set-key (kbd "C-c '") #'claude-code-ide-edit-prompt))
    ((eq claude-code-ide-terminal-backend 'eat)
     ;; For eat, we need to modify the semi-char mode map which is the default
     ;; We use local-set-key to make it buffer-local
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
     (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape)
-    (local-set-key (kbd "C-'") #'claude-code-ide-edit-prompt))
+    (local-set-key (kbd "C-c '") #'claude-code-ide-edit-prompt))
    (t
     (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))
 
@@ -1213,7 +1213,7 @@ If CLEAR-LINE is non-nil, send C-u to clear the current line first."
   (let ((buffer-name (claude-code-ide--get-buffer-name)))
     (if-let ((buffer (get-buffer buffer-name)))
         (let ((prompt-to-send (or prompt (read-string "Claude prompt: "))))
-          (when (not (string-empty-p prompt-to-send))
+          (when (or clear-line (not (string-empty-p prompt-to-send)))
             (with-current-buffer buffer
               (when clear-line
                 (if (eq claude-code-ide-terminal-backend 'vterm)
@@ -1221,7 +1221,8 @@ If CLEAR-LINE is non-nil, send C-u to clear the current line first."
                   (claude-code-ide--terminal-send-string "\C-u"))
                 ;; Give the terminal a moment to process the clear command
                 (sit-for 0.1))
-              (claude-code-ide--terminal-send-string prompt-to-send)
+              (unless (string-empty-p prompt-to-send)
+                (claude-code-ide--terminal-send-string prompt-to-send))
               (unless no-return
                 ;; Small delay to ensure prompt text is processed before sending return
                 (sit-for 0.1)
@@ -1262,17 +1263,11 @@ Press C-c C-c to update the terminal prompt (without sending) or C-c C-k to canc
         (erase-buffer)
         (when (and initial-input (not (string-empty-p initial-input)))
           (insert (string-trim initial-input)))
-        (if (fboundp 'with-editor-mode)
-            (progn
-              (with-editor-mode 1)
-              (setq-local with-editor-show-usage nil)
-              (setq-local with-editor-finish-query-functions nil)
-              (add-hook 'with-editor-finish-hook 'claude-code-ide--apply-prompt-buffer nil t)
-              (add-hook 'with-editor-cancel-hook 'claude-code-ide--cancel-prompt-buffer nil t))
-          ;; Fallback if with-editor is not installed
-          (use-local-map (copy-keymap text-mode-map))
-          (local-set-key (kbd "C-c C-c") 'claude-code-ide--apply-prompt-buffer)
-          (local-set-key (kbd "C-c C-k") 'claude-code-ide--cancel-prompt-buffer))
+        ;; Use an explicit local keymap so C-c C-c always applies the prompt
+        ;; instead of invoking editor/file-saving workflows.
+        (use-local-map (copy-keymap text-mode-map))
+        (local-set-key (kbd "C-c C-c") #'claude-code-ide--apply-prompt-buffer)
+        (local-set-key (kbd "C-c C-k") #'claude-code-ide--cancel-prompt-buffer)
         (message "Type your prompt and press C-c C-c to update, or C-c C-k to cancel."))
       (pop-to-buffer prompt-buffer))))
 
@@ -1288,7 +1283,7 @@ Press C-c C-c to update the terminal prompt (without sending) or C-c C-k to canc
       (set-window-configuration window-config))
     (when (buffer-live-p prompt-buffer)
       (kill-buffer prompt-buffer))
-    (when (and target-buffer (buffer-live-p target-buffer) (not (string-empty-p (string-trim prompt))))
+    (when (and target-buffer (buffer-live-p target-buffer))
       ;; Send with no-return=t and clear-line=t to overwrite the existing prompt
       (claude-code-ide-send-prompt (string-trim prompt) t t))))
 

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -1246,7 +1246,7 @@ Press C-c C-c to update the terminal prompt (without sending) or C-c C-k to canc
     (unless target-buffer
       (user-error "No Claude Code session for this project"))
     (let ((prompt-buffer (get-buffer-create (format "*Claude Prompt [%s]*"
-                                                     (file-name-nondirectory (directory-file-name working-dir)))))
+                                                    (file-name-nondirectory (directory-file-name working-dir)))))
           (initial-input (or region-text
                              (claude-code-ide--get-terminal-input target-buffer))))
       (with-current-buffer prompt-buffer
@@ -1295,7 +1295,16 @@ Press C-c C-c to update the terminal prompt (without sending) or C-c C-k to canc
                   (or (claude-code-ide--get-terminal-input-from-vterm)
                       (claude-code-ide--get-terminal-input-from-eat)
                       (claude-code-ide--get-terminal-input-from-text))))
-        (claude-code-ide--strip-terminal-prompt-prefix input)))))
+        (claude-code-ide--strip-terminal-prompt-prefix
+         (claude-code-ide--strip-terminal-footer input))))))
+
+(defun claude-code-ide--strip-terminal-footer (input)
+  "Strip Claude Code terminal footer/status text from INPUT.
+The Claude Code CLI renders status hints like
+\"{accept edits on (shift+tab to cycle)}\" below the prompt area.
+These appear on their own line enclosed in curly braces."
+  (replace-regexp-in-string
+   "[\n\r][[:space:]]*{[^}\n]*}[[:space:]]*\\'" "" input))
 
 (defun claude-code-ide--strip-terminal-prompt-prefix (input)
   "Strip a visible Claude prompt prefix from INPUT."


### PR DESCRIPTION
Adds `claude-code-ide-edit-prompt`, a command to edit the Claude terminal prompt in a dedicated text buffer instead of inline.

Key features: - Opens a `*Claude Prompt [project]*` buffer pre-filled with the current terminal input or active region - Supports `with-editor-mode` (C-c C-c to apply, C-c C-k to cancel) with a keymap fallback when unavailable - Restores window configuration on apply or cancel - `@` mention completion with project file candidates and filesystem path fallback for `~/`, `/`, `./`, `../` prefixes - Auto-triggers completion after typing following an `@` - Bound to `C-'` in terminal buffers and `P` in transient menu - Adds `with-editor` as a package dependency