### PR TITLE
Fix non-symbol checker/backend values causing symbolp errors

### DIFF
--- a/claude-code-ide-diagnostics.el
+++ b/claude-code-ide-diagnostics.el
@@ -120,7 +120,10 @@ Returns: 1 (Error), 2 (Warning), 3 (Information), 4 (Hint)."
                                                       1))))))
                     (severity . ,(claude-code-ide-diagnostics--severity-to-string
                                   (flycheck-error-level err)))
-                    (source . ,(or (flycheck-error-checker err) "flycheck"))
+                    (source . ,(let ((c (flycheck-error-checker err)))
+                                 (cond ((symbolp c) (if c (symbol-name c) "flycheck"))
+                                       ((stringp c) c)
+                                       (t "flycheck"))))
                     (message . ,(flycheck-error-message err))))
                 flycheck-current-errors)))))
 
@@ -145,8 +148,10 @@ Returns: 1 (Error), 2 (Warning), 3 (Information), 4 (Hint)."
                                           (character . ,end-col)))))
                         (severity . ,(claude-code-ide-diagnostics--severity-to-string
                                       (flymake-diagnostic-type diag)))
-                        (source . ,(symbol-name (or (flymake-diagnostic-backend diag)
-                                                    'flymake)))
+                        (source . ,(let ((b (or (flymake-diagnostic-backend diag) 'flymake)))
+                                     (cond ((symbolp b) (symbol-name b))
+                                           ((stringp b) b)
+                                           (t "flymake"))))
                         (message . ,(flymake-diagnostic-text diag))))))
                 (flymake-diagnostics))))))
 


### PR DESCRIPTION
When using flycheck-eglot or eglot's flymake with basedpyright/pyright, flycheck-error-checker and flymake-diagnostic-backend can return strings rather than symbols. 

The previous code called symbol-name unconditionally, producing 'Wrong type argument: symbolp' errors.

This patch handled both symbol and string values.

<img width="734" height="423" alt="Screenshot 2026-05-02 at 1 54 15 PM" src="https://github.com/user-attachments/assets/4c53883c-34a7-437f-8ff5-31d753757e57" />
