### PR TITLE
Fix eglot severity mapping

### DIFF
--- a/claude-code-ide-diagnostics.el
+++ b/claude-code-ide-diagnostics.el
@@ -102,7 +102,6 @@ Returns: 1 (Error), 2 (Warning), 3 (Information), 4 (Hint)."
     ('eglot-error "Error")
     ('eglot-warning "Warning")
     ('eglot-note "Information")
-    ('eglot-information "Information")
     ;; Default
     (_ "Information")))
 

--- a/claude-code-ide-diagnostics.el
+++ b/claude-code-ide-diagnostics.el
@@ -98,6 +98,11 @@ Returns: 1 (Error), 2 (Warning), 3 (Information), 4 (Hint)."
     (':warning "Warning")
     ('flymake-note "Information")
     (':note "Information")
+    ;; Eglot severities (eglot wraps flymake types with eglot- prefix)
+    ('eglot-error "Error")
+    ('eglot-warning "Warning")
+    ('eglot-note "Information")
+    ('eglot-information "Information")
     ;; Default
     (_ "Information")))
 


### PR DESCRIPTION



Without this patch, claude ide can't distinguish error, warning, and info. They all became information. 
Please see 
[Eglot source in Emacs source](https://github.com/emacs-mirror/emacs/blob/e05fab5775c96f8f88eab8d75dea40253bfb78eb/lisp/progmodes/eglot.el#L3293)
