### PR TITLE
Port `stevemolitor`'s features

### DIFF
--- a/README.org
+++ b/README.org
@@ -142,6 +142,16 @@ The easiest way to interact with Claude Code IDE is through the transient menu i
 | =M-x claude-code-ide-list-sessions=       | List all active Claude Code sessions and switch   |
 | =M-x claude-code-ide-check-status=        | Check if Claude Code CLI is installed and working |
 | =M-x claude-code-ide-insert-at-mentioned= | Send selected text to Claude prompt               |
+| =M-x claude-code-ide-send-region=         | Send the region (or whole buffer) to Claude       |
+| =M-x claude-code-ide-send-with-context=   | Send a command with current file/line context     |
+| =M-x claude-code-ide-send-buffer-file=    | Send the current buffer's file as @reference      |
+| =M-x claude-code-ide-send-file=           | Send a chosen file as an @reference               |
+| =M-x claude-code-ide-fix-error-at-point=  | Ask Claude to fix the diagnostic at point         |
+| =M-x claude-code-ide-send-return=         | Send a lone return (confirm a prompt)             |
+| =M-x claude-code-ide-send-1/2/3=          | Select option 1, 2, or 3 in a numbered menu       |
+| =M-x claude-code-ide-cycle-mode=          | Cycle Claude modes (sends Shift-Tab)              |
+| =M-x claude-code-ide-fork=                | Jump to a previous message (sends Escape-Escape)  |
+| =M-x claude-code-ide-toggle-read-only-mode= | Toggle read-only/copy mode in the terminal      |
 | =M-x claude-code-ide-send-escape=         | Send escape key to Claude terminal                |
 | =M-x claude-code-ide-insert-newline=      | Insert newline in Claude prompt (sends \ + Enter) |
 | =M-x claude-code-ide-toggle=              | Toggle visibility of Claude Code window           |
@@ -215,6 +225,7 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 | ~claude-code-ide-prevent-reflow-glitch~         | Prevent terminal reflow glitch (bug #1422)  | ~t~                                    |
 | ~claude-code-ide-enable-execute-code~           | Allow model to evaluate Elisp in Emacs      | ~t~                                    |
 | ~claude-code-ide-enable-resources~              | Expose files to Claude as MCP resources     | ~t~                                    |
+| ~claude-code-ide-large-buffer-threshold~        | Confirm before sending a buffer this large  | ~100000~                               |
 
 *** Side Window Configuration
 

--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ Claude Code IDE for Emacs provides native integration with Claude Code CLI throu
 - Image pasting into the terminal (Emacs 29+) and completion notifications when Claude awaits input
 - Extensible MCP tools server for accessing Emacs commands (xrefs, tree-sitter, project info, e.g.)
 - Diagnostic integration with Flycheck and Flymake
-- Advanced diff view with ediff integration (modify suggestions before applying)
+- Advanced diff view with a selectable backend: interactive ediff (modify suggestions before applying) or a simple read-only diff
 - Tab-bar support for proper context switching
 - Selection and buffer tracking for better context awareness
 
@@ -159,6 +159,7 @@ The easiest way to interact with Claude Code IDE is through the transient menu i
 | =M-x claude-code-ide-toggle-recent=       | Toggle most recent Claude window globally         |
 | =M-x claude-code-ide-show-debug=          | Show the debug buffer with WebSocket messages     |
 | =M-x claude-code-ide-clear-debug=         | Clear the debug buffer                            |
+| =M-x claude-code-ide-toggle-debug=        | Toggle debug logging of WebSocket/JSON-RPC        |
 
 ** Multi-Project Support
 
@@ -216,7 +217,9 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 | ~claude-code-ide-focus-claude-after-ediff~      | Focus Claude window after opening ediff     | ~t~                                    |
 | ~claude-code-ide-show-claude-window-in-ediff~   | Show Claude window during ediff             | ~t~                                    |
 | ~claude-code-ide-use-ide-diff~                  | Use IDE diff viewer instead of terminal     | ~t~                                    |
+| ~claude-code-ide-diff-tool~                      | Diff backend: ~ediff~ or ~simple~           | ~ediff~                                |
 | ~claude-code-ide-switch-tab-on-ediff~           | Switch to Claude's tab when opening ediff   | ~t~                                    |
+| ~claude-code-ide-enable-keepalive~              | Send periodic WebSocket keepalive pings     | ~nil~                                  |
 | ~claude-code-ide-system-prompt~                 | Custom system prompt to append              | ~nil~                                  |
 | ~claude-code-ide-enable-mcp-server~             | Enable MCP tools server                     | ~nil~                                  |
 | ~claude-code-ide-mcp-server-port~               | Port for MCP tools server                   | ~nil~ (auto-select)                    |

--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@ Claude Code IDE for Emacs provides native integration with Claude Code CLI throu
 - MCP protocol implementation for IDE integration
 - Tool support for file operations, editor state, and workspace info (selections, open editors, workspace folders, document save/dirty state)
 - MCP resources support for sharing open buffers, recent files, and project files with Claude
-- Image pasting into the terminal (Emacs 29+) and completion notifications when Claude awaits input
+- Completion notifications when Claude finishes and awaits your input
 - Extensible MCP tools server for accessing Emacs commands (xrefs, tree-sitter, project info, e.g.)
 - Diagnostic integration with Flycheck and Flymake
 - Advanced diff view with a selectable backend: interactive ediff (modify suggestions before applying) or a simple read-only diff
@@ -230,9 +230,6 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 | ~claude-code-ide-enable-execute-code~           | Allow model to evaluate Elisp in Emacs      | ~t~                                    |
 | ~claude-code-ide-enable-resources~              | Expose files to Claude as MCP resources     | ~t~                                    |
 | ~claude-code-ide-large-buffer-threshold~        | Confirm before sending a buffer this large  | ~100000~                               |
-| ~claude-code-ide-enable-image-paste~            | Enable image paste via ~yank-media~ (Emacs 29+) | ~t~                                |
-| ~claude-code-ide-image-paste-directory~         | Directory for pasted image temp files       | ~/tmp~ (or temp dir)                   |
-| ~claude-code-ide-image-paste-cleanup-on-kill~   | Delete pasted images when buffer is killed  | ~t~                                    |
 | ~claude-code-ide-enable-notifications~          | Notify when Claude finishes and awaits input | ~t~                                   |
 | ~claude-code-ide-notification-function~         | Function called to notify the user          | ~claude-code-ide-default-notification~ |
 

--- a/README.org
+++ b/README.org
@@ -219,7 +219,6 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 | ~claude-code-ide-use-ide-diff~                  | Use IDE diff viewer instead of terminal     | ~t~                                    |
 | ~claude-code-ide-diff-tool~                      | Diff backend: ~ediff~ or ~simple~           | ~ediff~                                |
 | ~claude-code-ide-switch-tab-on-ediff~           | Switch to Claude's tab when opening ediff   | ~t~                                    |
-| ~claude-code-ide-enable-keepalive~              | Send periodic WebSocket keepalive pings     | ~nil~                                  |
 | ~claude-code-ide-system-prompt~                 | Custom system prompt to append              | ~nil~                                  |
 | ~claude-code-ide-enable-mcp-server~             | Enable MCP tools server                     | ~nil~                                  |
 | ~claude-code-ide-mcp-server-port~               | Port for MCP tools server                   | ~nil~ (auto-select)                    |

--- a/README.org
+++ b/README.org
@@ -20,6 +20,7 @@ Claude Code IDE for Emacs provides native integration with Claude Code CLI throu
 - MCP protocol implementation for IDE integration
 - Tool support for file operations, editor state, and workspace info (selections, open editors, workspace folders, document save/dirty state)
 - MCP resources support for sharing open buffers, recent files, and project files with Claude
+- Image pasting into the terminal (Emacs 29+) and completion notifications when Claude awaits input
 - Extensible MCP tools server for accessing Emacs commands (xrefs, tree-sitter, project info, e.g.)
 - Diagnostic integration with Flycheck and Flymake
 - Advanced diff view with ediff integration (modify suggestions before applying)
@@ -226,6 +227,11 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 | ~claude-code-ide-enable-execute-code~           | Allow model to evaluate Elisp in Emacs      | ~t~                                    |
 | ~claude-code-ide-enable-resources~              | Expose files to Claude as MCP resources     | ~t~                                    |
 | ~claude-code-ide-large-buffer-threshold~        | Confirm before sending a buffer this large  | ~100000~                               |
+| ~claude-code-ide-enable-image-paste~            | Enable image paste via ~yank-media~ (Emacs 29+) | ~t~                                |
+| ~claude-code-ide-image-paste-directory~         | Directory for pasted image temp files       | ~/tmp~ (or temp dir)                   |
+| ~claude-code-ide-image-paste-cleanup-on-kill~   | Delete pasted images when buffer is killed  | ~t~                                    |
+| ~claude-code-ide-enable-notifications~          | Notify when Claude finishes and awaits input | ~t~                                   |
+| ~claude-code-ide-notification-function~         | Function called to notify the user          | ~claude-code-ide-default-notification~ |
 
 *** Side Window Configuration
 

--- a/README.org
+++ b/README.org
@@ -18,7 +18,8 @@ Claude Code IDE for Emacs provides native integration with Claude Code CLI throu
 - Automatic project detection and session management
 - Terminal integration with full color support using =vterm=, =eat=, or =ghostel=
 - MCP protocol implementation for IDE integration
-- Tool support for file operations, editor state, and workspace info
+- Tool support for file operations, editor state, and workspace info (selections, open editors, workspace folders, document save/dirty state)
+- MCP resources support for sharing open buffers, recent files, and project files with Claude
 - Extensible MCP tools server for accessing Emacs commands (xrefs, tree-sitter, project info, e.g.)
 - Diagnostic integration with Flycheck and Flymake
 - Advanced diff view with ediff integration (modify suggestions before applying)
@@ -213,6 +214,7 @@ This allows you to refine Claude's suggestions before they're applied, ensuring 
 | ~claude-code-ide-no-flicker~                    | Enable flicker-free terminal renderer       | ~nil~                                  |
 | ~claude-code-ide-prevent-reflow-glitch~         | Prevent terminal reflow glitch (bug #1422)  | ~t~                                    |
 | ~claude-code-ide-enable-execute-code~           | Allow model to evaluate Elisp in Emacs      | ~t~                                    |
+| ~claude-code-ide-enable-resources~              | Expose files to Claude as MCP resources     | ~t~                                    |
 
 *** Side Window Configuration
 

--- a/claude-code-ide-debug.el
+++ b/claude-code-ide-debug.el
@@ -77,6 +77,16 @@ This is a macro to avoid evaluating ARGS when debugging is disabled."
     (message "%s %s" (claude-code-ide--get-session-context) message)))
 
 ;;;###autoload
+(defun claude-code-ide-toggle-debug ()
+  "Toggle debug logging of WebSocket/JSON-RPC traffic on or off.
+When enabled, messages are logged to `claude-code-ide-debug-buffer';
+view it with `claude-code-ide-show-debug'."
+  (interactive)
+  (setq claude-code-ide-debug (not claude-code-ide-debug))
+  (message "Claude Code IDE debug logging %s"
+           (if claude-code-ide-debug "enabled" "disabled")))
+
+;;;###autoload
 (defun claude-code-ide-show-debug ()
   "Show the debug buffer."
   (interactive)

--- a/claude-code-ide-mcp-handlers.el
+++ b/claude-code-ide-mcp-handlers.el
@@ -35,6 +35,8 @@
 (require 'claude-code-ide-debug)
 
 (declare-function claude-code-ide-mcp-complete-deferred "claude-code-ide-mcp" (session method result &optional unique-key))
+(declare-function claude-code-ide-mcp--get-current-selection "claude-code-ide-mcp" ())
+(declare-function claude-code-ide-mcp-session-last-buffer "claude-code-ide-mcp" (session))
 (declare-function claude-code-ide-mcp--get-current-session "claude-code-ide-mcp" ())
 (declare-function claude-code-ide-mcp--get-session-for-project "claude-code-ide-mcp" (project-dir))
 (declare-function claude-code-ide-mcp--get-buffer-project "claude-code-ide-mcp" ())
@@ -53,6 +55,7 @@
 (defvar claude-code-ide-focus-claude-after-ediff)
 (defvar claude-code-ide-switch-tab-on-ediff)
 (defvar claude-code-ide-use-ide-diff)
+(defvar claude-code-ide-enable-resources)
 
 ;;; Tool Registry - Define variables first to ensure they're available
 
@@ -647,6 +650,123 @@ ARGUMENTS should contain:
       (error
        (signal 'mcp-error (list (format "Evaluation error: %s" (error-message-string err))))))))
 
+;;; IDE State Tools
+
+(defun claude-code-ide-mcp--selection-data (buffer)
+  "Build a selection payload for BUFFER including the `isEmpty' flag.
+Reuses `claude-code-ide-mcp--get-current-selection' and adds the
+`isEmpty' field expected by the IDE protocol."
+  (with-current-buffer buffer
+    (let* ((sel (claude-code-ide-mcp--get-current-selection))
+           (is-empty (if (use-region-p) :json-false t)))
+      `((text . ,(alist-get 'text sel))
+        (filePath . ,(alist-get 'filePath sel))
+        (selection . ,(cons `(isEmpty . ,is-empty)
+                            (alist-get 'selection sel)))))))
+
+(defun claude-code-ide-mcp--empty-selection-data ()
+  "Return an empty selection payload."
+  '((text . "")
+    (filePath . "")
+    (selection . ((start . ((line . 0) (character . 0)))
+                  (end . ((line . 0) (character . 0)))
+                  (isEmpty . t)))))
+
+(defun claude-code-ide-mcp-handle-get-current-selection (_arguments &optional session)
+  "Return the current selection.
+Operates on the session's last active file buffer when available so the
+result reflects the user's buffer rather than the Claude terminal.
+Optional SESSION provides that buffer."
+  (let* ((last-buffer (and session
+                           (claude-code-ide-mcp-session-last-buffer session)))
+         (buffer (if (and last-buffer (buffer-live-p last-buffer))
+                     last-buffer
+                   (current-buffer))))
+    (list `((type . "text")
+            (text . ,(json-encode (claude-code-ide-mcp--selection-data buffer)))))))
+
+(defun claude-code-ide-mcp-handle-get-latest-selection (_arguments)
+  "Return the most recently selected text across all file buffers."
+  (let ((data nil)
+        (latest -1))
+    (dolist (buffer (buffer-list))
+      (with-current-buffer buffer
+        (when (and (buffer-file-name)
+                   (use-region-p)
+                   (> (buffer-modified-tick) latest))
+          (setq latest (buffer-modified-tick)
+                data (claude-code-ide-mcp--selection-data buffer)))))
+    (list `((type . "text")
+            (text . ,(json-encode (or data (claude-code-ide-mcp--empty-selection-data))))))))
+
+(defun claude-code-ide-mcp-handle-get-open-editors (_arguments)
+  "Return the list of open file-visiting buffers."
+  (let ((editors '()))
+    (dolist (buffer (buffer-list))
+      (when-let ((file (buffer-file-name buffer)))
+        (push `((uri . ,(concat "file://" file))
+                (name . ,(file-name-nondirectory file))
+                (path . ,file))
+              editors)))
+    (list `((type . "text")
+            (text . ,(json-encode `((editors . ,(vconcat (nreverse editors))))))))))
+
+(defun claude-code-ide-mcp-handle-get-workspace-folders (_arguments &optional session)
+  "Return the workspace folders (project roots).
+Includes the session's project directory and the current project root.
+Optional SESSION provides the session project directory."
+  (let ((folders '())
+        (seen (make-hash-table :test 'equal)))
+    (dolist (dir (list (and session (claude-code-ide-mcp-session-project-dir session))
+                       (when-let ((project (project-current)))
+                         (project-root project))))
+      (when dir
+        (let ((root (file-name-as-directory (expand-file-name dir))))
+          (unless (gethash root seen)
+            (puthash root t seen)
+            (push `((uri . ,(concat "file://" root))
+                    (name . ,(file-name-nondirectory (directory-file-name root))))
+                  folders)))))
+    (list `((type . "text")
+            (text . ,(json-encode `((folders . ,(vconcat (nreverse folders))))))))))
+
+(defun claude-code-ide-mcp--arg-file-path (arguments)
+  "Extract a local file path from ARGUMENTS.
+Accepts `filePath', `uri', or `path', stripping a leading file:// scheme."
+  (when-let ((path (or (alist-get 'filePath arguments)
+                       (alist-get 'uri arguments)
+                       (alist-get 'path arguments))))
+    (if (string-prefix-p "file://" path)
+        (substring path 7)
+      path)))
+
+(defun claude-code-ide-mcp-handle-check-document-dirty (arguments)
+  "Report whether the document in ARGUMENTS has unsaved changes."
+  (let ((path (claude-code-ide-mcp--arg-file-path arguments)))
+    (unless path
+      (signal 'mcp-error '("Missing required parameter: filePath")))
+    (let ((buffer (find-buffer-visiting path)))
+      (list `((type . "text")
+              (text . ,(json-encode
+                        `((isDirty . ,(if (and buffer (buffer-modified-p buffer))
+                                          t
+                                        :json-false))))))))))
+
+(defun claude-code-ide-mcp-handle-save-document (arguments)
+  "Save the document referenced by ARGUMENTS to disk."
+  (let ((path (claude-code-ide-mcp--arg-file-path arguments)))
+    (unless path
+      (signal 'mcp-error '("Missing required parameter: filePath")))
+    (let ((buffer (find-buffer-visiting path)))
+      (if buffer
+          (with-current-buffer buffer
+            (save-buffer)
+            (list `((type . "text")
+                    (text . ,(json-encode '((saved . t)))))))
+        (list `((type . "text")
+                (text . ,(json-encode '((saved . :json-false)
+                                        (error . "File not open"))))))))))
+
 ;;; Tool Registry - Set the values
 
 (defun claude-code-ide-mcp--build-tool-list ()
@@ -654,6 +774,12 @@ ARGUMENTS should contain:
   `(("openFile" . claude-code-ide-mcp-handle-open-file)
     ("getDiagnostics" . claude-code-ide-mcp-handle-get-diagnostics)
     ("close_tab" . claude-code-ide-mcp-handle-close-tab)
+    ("getCurrentSelection" . claude-code-ide-mcp-handle-get-current-selection)
+    ("getLatestSelection" . claude-code-ide-mcp-handle-get-latest-selection)
+    ("getOpenEditors" . claude-code-ide-mcp-handle-get-open-editors)
+    ("getWorkspaceFolders" . claude-code-ide-mcp-handle-get-workspace-folders)
+    ("checkDocumentDirty" . claude-code-ide-mcp-handle-check-document-dirty)
+    ("saveDocument" . claude-code-ide-mcp-handle-save-document)
     ,@(when (bound-and-true-p claude-code-ide-use-ide-diff)
         '(("openDiff" . claude-code-ide-mcp-handle-open-diff)
           ("closeAllDiffTabs" . claude-code-ide-mcp-handle-close-all-diff-tabs)))
@@ -686,6 +812,22 @@ ARGUMENTS should contain:
                                    (tab_name . ((type . "string")
                                                 (description . "Name of the tab to close")))))
                     (required . [])))
+    ("getCurrentSelection" . ((type . "object")
+                              (properties . :json-empty)))
+    ("getLatestSelection" . ((type . "object")
+                             (properties . :json-empty)))
+    ("getOpenEditors" . ((type . "object")
+                         (properties . :json-empty)))
+    ("getWorkspaceFolders" . ((type . "object")
+                              (properties . :json-empty)))
+    ("checkDocumentDirty" . ((type . "object")
+                             (properties . ((filePath . ((type . "string")
+                                                         (description . "Path to the file to check")))))
+                             (required . ["filePath"])))
+    ("saveDocument" . ((type . "object")
+                       (properties . ((filePath . ((type . "string")
+                                                   (description . "Path to the file to save")))))
+                       (required . ["filePath"])))
     ,@(when (bound-and-true-p claude-code-ide-use-ide-diff)
         '(("openDiff" . ((type . "object")
                          (properties . ((old_file_path . ((type . "string")
@@ -712,6 +854,12 @@ ARGUMENTS should contain:
   `(("openFile" . "Open a file in the editor and optionally select a range of text")
     ("getDiagnostics" . "Get language diagnostics from Emacs")
     ("close_tab" . "Close a tab/buffer")
+    ("getCurrentSelection" . "Get the current text selection in the active editor")
+    ("getLatestSelection" . "Get the most recent text selection across all editors")
+    ("getOpenEditors" . "Get the list of currently open file editors")
+    ("getWorkspaceFolders" . "Get the workspace folders (project roots)")
+    ("checkDocumentDirty" . "Check whether a document has unsaved changes")
+    ("saveDocument" . "Save a document to disk")
     ,@(when (bound-and-true-p claude-code-ide-use-ide-diff)
         '(("openDiff" . "Open a diff view comparing old and new file contents")
           ("closeAllDiffTabs" . "Close all open diff tabs in the current session")))

--- a/claude-code-ide-mcp-handlers.el
+++ b/claude-code-ide-mcp-handlers.el
@@ -55,6 +55,7 @@
 (defvar claude-code-ide-focus-claude-after-ediff)
 (defvar claude-code-ide-switch-tab-on-ediff)
 (defvar claude-code-ide-use-ide-diff)
+(defvar claude-code-ide-diff-tool)
 (defvar claude-code-ide-enable-resources)
 
 ;;; Tool Registry - Define variables first to ensure they're available
@@ -383,12 +384,13 @@ ARGUMENTS should contain `path' or `tab_name' of the file to close."
       (signal 'mcp-error '("Either 'path' or 'tab_name' must be provided"))))))
 
 (defun claude-code-ide-mcp-handle-open-diff (arguments)
-  "Open a diff view using ediff.
+  "Open a diff view for ARGUMENTS using the configured diff backend.
 ARGUMENTS should contain:
 - `old_file_path': Original file path
 - `new_file_path': New file path (usually same as old)
 - `new_file_contents': New content to diff against
-- `tab_name': Name for the diff tab"
+- `tab_name': Name for the diff tab
+The backend is selected by `claude-code-ide-diff-tool'."
   (let ((old-file-path (alist-get 'old_file_path arguments))
         (new-file-path (alist-get 'new_file_path arguments))
         (new-file-contents (alist-get 'new_file_contents arguments))
@@ -430,6 +432,18 @@ ARGUMENTS should contain:
               ;; Switch to the original tab
               (tab-bar-select-tab-by-name (alist-get 'name original-tab)))))))
 
+    ;; Dispatch to the configured diff backend
+    (if (eq claude-code-ide-diff-tool 'simple)
+        (claude-code-ide-mcp--open-diff-simple
+         old-file-path new-file-path new-file-contents tab-name session)
+      (claude-code-ide-mcp--open-diff-ediff
+       old-file-path new-file-path new-file-contents tab-name session))))
+
+(defun claude-code-ide-mcp--open-diff-ediff (old-file-path new-file-path new-file-contents tab-name session)
+  "Open an interactive ediff for TAB-NAME in SESSION.
+OLD-FILE-PATH, NEW-FILE-PATH and NEW-FILE-CONTENTS describe the diff.
+Returns a deferred-response indicator."
+  (progn
     ;; Save current window configuration
     (let* ((saved-winconf (current-window-configuration))
            (buffers (claude-code-ide-mcp--create-diff-buffers
@@ -576,6 +590,7 @@ SESSION is the MCP session to use - if not provided, tries to determine it."
       (let ((buffer-A (alist-get 'buffer-A diff-info))
             (buffer-B (alist-get 'buffer-B diff-info))
             (control-buf (alist-get 'control-buffer diff-info))
+            (simple-diff-buffer (alist-get 'simple-diff-buffer diff-info))
             (file-exists (alist-get 'file-exists diff-info))
             ;; First try to get buffers from diff-info (stored during close_tab)
             (error-buffer (alist-get 'error-buffer diff-info))
@@ -602,6 +617,9 @@ SESSION is the MCP session to use - if not provided, tries to determine it."
           (when (and buf (buffer-live-p buf))
             (claude-code-ide-debug "Killing ediff auxiliary buffer: %s" (buffer-name buf))
             (kill-buffer buf)))
+        ;; Kill the simple diff display buffer if present
+        (when (and simple-diff-buffer (buffer-live-p simple-diff-buffer))
+          (kill-buffer simple-diff-buffer))
         ;; Kill the temporary buffer (buffer B)
         (when (and buffer-B (buffer-live-p buffer-B))
           (kill-buffer buffer-B))
@@ -611,6 +629,89 @@ SESSION is the MCP session to use - if not provided, tries to determine it."
           (kill-buffer buffer-A))
         ;; Remove from active diffs
         (remhash tab-name active-diffs)))))
+
+;;; Simple diff backend
+
+(defun claude-code-ide-mcp--simple-diff-accept (tab-name session)
+  "Accept the simple diff for TAB-NAME in SESSION.
+Sends the new content back to Claude and cleans up."
+  (interactive)
+  (let* ((active-diffs (claude-code-ide-mcp--get-active-diffs session))
+         (diff-info (gethash tab-name active-diffs))
+         (buffer-B (alist-get 'buffer-B diff-info))
+         (saved-winconf (alist-get 'saved-winconf diff-info))
+         (content (when (and buffer-B (buffer-live-p buffer-B))
+                    (with-current-buffer buffer-B (buffer-string)))))
+    (claude-code-ide-mcp-complete-deferred
+     session "openDiff"
+     (list `((type . "text") (text . "FILE_SAVED"))
+           `((type . "text") (text . ,(or content ""))))
+     tab-name)
+    (claude-code-ide-mcp--cleanup-diff tab-name session)
+    (when saved-winconf
+      (set-window-configuration saved-winconf))))
+
+(defun claude-code-ide-mcp--simple-diff-reject (tab-name session)
+  "Reject the simple diff for TAB-NAME in SESSION."
+  (interactive)
+  (let* ((active-diffs (claude-code-ide-mcp--get-active-diffs session))
+         (diff-info (gethash tab-name active-diffs))
+         (saved-winconf (alist-get 'saved-winconf diff-info)))
+    (claude-code-ide-mcp-complete-deferred
+     session "openDiff"
+     (list `((type . "text") (text . "DIFF_REJECTED"))
+           `((type . "text") (text . ,tab-name)))
+     tab-name)
+    (claude-code-ide-mcp--cleanup-diff tab-name session)
+    (when saved-winconf
+      (set-window-configuration saved-winconf))))
+
+(defun claude-code-ide-mcp--open-diff-simple (old-file-path new-file-path new-file-contents tab-name session)
+  "Show a read-only `diff-mode' diff for TAB-NAME in SESSION.
+OLD-FILE-PATH, NEW-FILE-PATH and NEW-FILE-CONTENTS describe the diff.
+Press \\`y' to accept the change or \\`q' to reject it.  Returns a
+deferred-response indicator."
+  (let* ((saved-winconf (current-window-configuration))
+         (buffers (claude-code-ide-mcp--create-diff-buffers
+                   old-file-path new-file-contents tab-name))
+         (buffer-A (car buffers))
+         (buffer-B (cdr buffers))
+         (file-exists (file-exists-p old-file-path))
+         (diff-buf (get-buffer-create (format "*claude-diff: %s*" tab-name)))
+         (active-diffs (claude-code-ide-mcp--get-active-diffs session)))
+    ;; Build the diff into our buffer (synchronously)
+    (diff-no-select buffer-A buffer-B nil t diff-buf)
+    (puthash tab-name
+             `((buffer-A . ,buffer-A)
+               (buffer-B . ,buffer-B)
+               (old-file-path . ,old-file-path)
+               (new-file-path . ,new-file-path)
+               (file-exists . ,file-exists)
+               (saved-winconf . ,saved-winconf)
+               (simple-diff-buffer . ,diff-buf)
+               (session . ,session)
+               (created-at . ,(current-time)))
+             active-diffs)
+    (with-current-buffer diff-buf
+      (setq buffer-read-only t)
+      (let ((map (make-sparse-keymap)))
+        (set-keymap-parent map (current-local-map))
+        (define-key map (kbd "y")
+                    (lambda () (interactive)
+                      (claude-code-ide-mcp--simple-diff-accept tab-name session)))
+        (define-key map (kbd "q")
+                    (lambda () (interactive)
+                      (claude-code-ide-mcp--simple-diff-reject tab-name session)))
+        (define-key map (kbd "n")
+                    (lambda () (interactive)
+                      (claude-code-ide-mcp--simple-diff-reject tab-name session)))
+        (use-local-map map))
+      (goto-char (point-min)))
+    (pop-to-buffer diff-buf)
+    (message "Claude diff: press y to accept, q to reject")
+    `((deferred . t)
+      (unique-key . ,tab-name)
+      (session . ,session))))
 
 (defun claude-code-ide-mcp-handle-close-all-diff-tabs (_arguments)
   "Close all diff tabs/buffers for the current session only."

--- a/claude-code-ide-mcp.el
+++ b/claude-code-ide-mcp.el
@@ -254,14 +254,12 @@ Returns the session if found, nil otherwise."
         (error
          (claude-code-ide-debug "Failed to send notification %s: %s" method err))))))
 
-(defun claude-code-ide-mcp--handle-initialize (id _params &optional session)
-  "Handle the initialize request with ID.
-Optional SESSION is the MCP session; when keepalive is enabled, its ping
-timer is started here."
+(defun claude-code-ide-mcp--handle-initialize (id _params)
+  "Handle the initialize request with ID."
   (claude-code-ide-debug "Handling initialize request with id: %s" id)
-  ;; Start ping timer after successful initialization, when keepalive is enabled
-  (when (and session (bound-and-true-p claude-code-ide-enable-keepalive))
-    (claude-code-ide-mcp--start-ping-timer session))
+  ;; Start ping timer after successful initialization
+  ;; DISABLED: Ping causing connection issues - needs investigation
+  ;; (claude-code-ide-mcp--start-ping-timer)
 
   ;; Send tools/list_changed notification after initialization
   (claude-code-ide-debug "Scheduling tools/list_changed notification")
@@ -492,7 +490,7 @@ Optional SESSION contains the MCP session context."
              ;; Request handlers
              ((string= method "initialize")
               (claude-code-ide-debug "Handling initialize request")
-              (claude-code-ide-mcp--handle-initialize id params session))
+              (claude-code-ide-mcp--handle-initialize id params))
              ((string= method "tools/list")
               (claude-code-ide-debug "Handling tools/list request")
               (claude-code-ide-mcp--handle-tools-list id params))

--- a/claude-code-ide-mcp.el
+++ b/claude-code-ide-mcp.el
@@ -270,16 +270,17 @@ Returns the session if found, nil otherwise."
                      "notifications/tools/list_changed"
                      (make-hash-table :test 'equal))))
 
-  (let ((response `((protocolVersion . ,claude-code-ide-mcp-version)
-                    (capabilities . ((tools . ((listChanged . t)))
-                                     (resources . ((subscribe . :json-false)
-                                                   (listChanged . :json-false)))
-                                     (prompts . ((listChanged . t)))
-                                     (logging . ,(make-hash-table :test 'equal))))
-                    (serverInfo . ((name . "claude-code-ide-mcp")
-                                   (version . "0.1.0"))))))
+  (let* ((resources-enabled (bound-and-true-p claude-code-ide-enable-resources))
+         (response `((protocolVersion . ,claude-code-ide-mcp-version)
+                     (capabilities . ((tools . ((listChanged . t)))
+                                      (resources . ((subscribe . :json-false)
+                                                    (listChanged . ,(if resources-enabled t :json-false))))
+                                      (prompts . ((listChanged . t)))
+                                      (logging . ,(make-hash-table :test 'equal))))
+                     (serverInfo . ((name . "claude-code-ide-mcp")
+                                    (version . "0.1.0"))))))
     (claude-code-ide-debug "Initialize response capabilities: tools.listChanged=%s, resources.subscribe=%s, resources.listChanged=%s, prompts.listChanged=%s"
-                           t :json-false :json-false t)
+                           t :json-false (if resources-enabled t :json-false) t)
     (claude-code-ide-mcp--make-response id response)))
 
 (defun claude-code-ide-mcp--prepare-schema-for-json (schema)
@@ -334,6 +335,89 @@ turn into {}. Recursively processes nested structures."
   ;; Return empty prompts list for now - Claude Code doesn't require any prompts
   (claude-code-ide-mcp--make-response id '((prompts . []))))
 
+;;; Resources
+
+(defconst claude-code-ide-mcp--mime-types
+  '(("txt" . "text/plain") ("md" . "text/markdown") ("org" . "text/org")
+    ("rst" . "text/x-rst") ("el" . "text/x-elisp") ("lisp" . "text/x-lisp")
+    ("scm" . "text/x-scheme") ("clj" . "text/x-clojure") ("py" . "text/x-python")
+    ("js" . "text/javascript") ("jsx" . "text/jsx") ("ts" . "text/typescript")
+    ("tsx" . "text/tsx") ("java" . "text/x-java") ("c" . "text/x-c")
+    ("cpp" . "text/x-c++") ("cc" . "text/x-c++") ("cxx" . "text/x-c++")
+    ("h" . "text/x-c") ("hpp" . "text/x-c++") ("cs" . "text/x-csharp")
+    ("go" . "text/x-go") ("rs" . "text/x-rust") ("rb" . "text/x-ruby")
+    ("php" . "text/x-php") ("swift" . "text/x-swift") ("kt" . "text/x-kotlin")
+    ("scala" . "text/x-scala") ("r" . "text/x-r") ("lua" . "text/x-lua")
+    ("pl" . "text/x-perl") ("html" . "text/html") ("htm" . "text/html")
+    ("xml" . "text/xml") ("css" . "text/css") ("scss" . "text/x-scss")
+    ("sass" . "text/x-sass") ("less" . "text/x-less") ("json" . "application/json")
+    ("yaml" . "text/yaml") ("yml" . "text/yaml") ("toml" . "text/x-toml")
+    ("ini" . "text/x-ini") ("sh" . "text/x-sh") ("bash" . "text/x-bash")
+    ("zsh" . "text/x-zsh") ("fish" . "text/x-fish") ("cmake" . "text/x-cmake")
+    ("tex" . "text/x-latex"))
+  "Alist mapping file extensions to MIME types for MCP resources.")
+
+(defun claude-code-ide-mcp--get-mime-type (file-path)
+  "Return the MIME type for FILE-PATH based on its extension."
+  (or (cdr (assoc (file-name-extension file-path)
+                  claude-code-ide-mcp--mime-types))
+      "text/plain"))
+
+(defun claude-code-ide-mcp--get-file-resources ()
+  "Return a list of file resources: open buffers, recent files, project files."
+  (let ((resources '())
+        (seen (make-hash-table :test 'equal)))
+    (cl-flet ((add-resource (file description)
+                (let ((uri (concat "file://" file)))
+                  (unless (gethash uri seen)
+                    (puthash uri t seen)
+                    (push `((uri . ,uri)
+                            (name . ,(file-name-nondirectory file))
+                            (description . ,description)
+                            (mimeType . ,(claude-code-ide-mcp--get-mime-type file)))
+                          resources)))))
+      ;; Open file buffers
+      (dolist (buffer (buffer-list))
+        (when-let ((file (buffer-file-name buffer)))
+          (add-resource file (format "Open file in buffer: %s" (buffer-name buffer)))))
+      ;; Recent files (limit to 20).  Guard so a failure here never breaks listing.
+      (condition-case err
+          (when (bound-and-true-p recentf-list)
+            (dolist (file (seq-take recentf-list 20))
+              (when (file-exists-p file)
+                (add-resource file "Recent file"))))
+        (error (claude-code-ide-debug "Skipping recent files in resources: %s" err)))
+      ;; Project files (limit to 50).  Guard so a failure here never breaks listing.
+      (condition-case err
+          (when-let* ((project (project-current))
+                      (root (project-root project)))
+            (dolist (file (seq-take (project-files project) 50))
+              (let ((full-path (expand-file-name file root)))
+                (when (file-regular-p full-path)
+                  (add-resource full-path "Project file")))))
+        (error (claude-code-ide-debug "Skipping project files in resources: %s" err))))
+    (nreverse resources)))
+
+(defun claude-code-ide-mcp--handle-resources-list (id _params)
+  "Handle the resources/list request with ID."
+  (claude-code-ide-mcp--make-response
+   id `((resources . ,(vconcat (claude-code-ide-mcp--get-file-resources))))))
+
+(defun claude-code-ide-mcp--handle-resources-read (id params)
+  "Handle the resources/read request with ID and PARAMS."
+  (let* ((uri (alist-get 'uri params))
+         (file-path (when (and uri (string-prefix-p "file://" uri))
+                      (substring uri 7))))
+    (if (and file-path (file-exists-p file-path))
+        (claude-code-ide-mcp--make-response
+         id `((contents . ,(vector `((uri . ,uri)
+                                     (mimeType . ,(claude-code-ide-mcp--get-mime-type file-path))
+                                     (text . ,(with-temp-buffer
+                                                (insert-file-contents file-path)
+                                                (buffer-string))))))))
+      (claude-code-ide-mcp--make-error-response
+       id -32602 (format "Resource not found: %s" uri)))))
+
 (defun claude-code-ide-mcp--handle-tools-call (id params &optional session)
   "Handle the tools/call request with ID and PARAMS.
 Optional SESSION contains the MCP session context."
@@ -347,7 +431,9 @@ Optional SESSION contains the MCP session context."
         (condition-case err
             (progn
               (claude-code-ide-debug "Found handler for tool: %s" tool-name)
-              (let ((result (if (member tool-name '("getDiagnostics"))
+              (let ((result (if (member tool-name '("getDiagnostics"
+                                                    "getCurrentSelection"
+                                                    "getWorkspaceFolders"))
                                 ;; Pass session to handlers that need it
                                 (funcall handler arguments session)
                               (funcall handler arguments))))
@@ -414,6 +500,14 @@ Optional SESSION contains the MCP session context."
              ((string= method "prompts/list")
               (claude-code-ide-debug "Handling prompts/list request")
               (claude-code-ide-mcp--handle-prompts-list id params))
+             ((and (string= method "resources/list")
+                   (bound-and-true-p claude-code-ide-enable-resources))
+              (claude-code-ide-debug "Handling resources/list request")
+              (claude-code-ide-mcp--handle-resources-list id params))
+             ((and (string= method "resources/read")
+                   (bound-and-true-p claude-code-ide-enable-resources))
+              (claude-code-ide-debug "Handling resources/read request")
+              (claude-code-ide-mcp--handle-resources-read id params))
              ;; Unknown method
              (id
               (claude-code-ide-debug "Unknown method: %s (sending error response)" method)

--- a/claude-code-ide-mcp.el
+++ b/claude-code-ide-mcp.el
@@ -254,12 +254,14 @@ Returns the session if found, nil otherwise."
         (error
          (claude-code-ide-debug "Failed to send notification %s: %s" method err))))))
 
-(defun claude-code-ide-mcp--handle-initialize (id _params)
-  "Handle the initialize request with ID."
+(defun claude-code-ide-mcp--handle-initialize (id _params &optional session)
+  "Handle the initialize request with ID.
+Optional SESSION is the MCP session; when keepalive is enabled, its ping
+timer is started here."
   (claude-code-ide-debug "Handling initialize request with id: %s" id)
-  ;; Start ping timer after successful initialization
-  ;; DISABLED: Ping causing connection issues - needs investigation
-  ;; (claude-code-ide-mcp--start-ping-timer)
+  ;; Start ping timer after successful initialization, when keepalive is enabled
+  (when (and session (bound-and-true-p claude-code-ide-enable-keepalive))
+    (claude-code-ide-mcp--start-ping-timer session))
 
   ;; Send tools/list_changed notification after initialization
   (claude-code-ide-debug "Scheduling tools/list_changed notification")
@@ -490,7 +492,7 @@ Optional SESSION contains the MCP session context."
              ;; Request handlers
              ((string= method "initialize")
               (claude-code-ide-debug "Handling initialize request")
-              (claude-code-ide-mcp--handle-initialize id params))
+              (claude-code-ide-mcp--handle-initialize id params session))
              ((string= method "tools/list")
               (claude-code-ide-debug "Handling tools/list request")
               (claude-code-ide-mcp--handle-tools-list id params))

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -2652,34 +2652,7 @@ have completed before cleanup.  Waits up to 5 seconds."
           (should (equal (reverse states) '(t nil))))
       (kill-buffer bufname))))
 
-;;; Tests for Image Paste and Notifications (Phase 3 port)
-
-(ert-deftest claude-code-ide-test-image-extension-for-mimetype ()
-  "Test MIME type to file extension mapping."
-  (should (equal (claude-code-ide--image-extension-for-mimetype "image/png") ".png"))
-  (should (equal (claude-code-ide--image-extension-for-mimetype 'image/jpeg) ".jpg"))
-  (should (equal (claude-code-ide--image-extension-for-mimetype "image/gif") ".gif"))
-  (should (equal (claude-code-ide--image-extension-for-mimetype "image/webp") ".webp"))
-  (should (equal (claude-code-ide--image-extension-for-mimetype "image/unknown") ".png")))
-
-(ert-deftest claude-code-ide-test-image-yank-media-handler ()
-  "Test image paste writes a temp file and injects an @path reference."
-  (let ((sent nil))
-    (cl-letf (((symbol-function 'claude-code-ide--terminal-send-string)
-               (lambda (s) (setq sent s))))
-      (with-temp-buffer
-        (let ((claude-code-ide-image-paste-directory temporary-file-directory)
-              (claude-code-ide-image-paste-cleanup-on-kill t))
-          (should (claude-code-ide--image-yank-media-handler "image/png" "fakedata"))
-          (should (= (length claude-code-ide--pasted-image-files) 1))
-          (let ((path (car claude-code-ide--pasted-image-files)))
-            (should (file-exists-p path))
-            (should (string-suffix-p ".png" path))
-            (should (equal sent (concat "@" path " ")))
-            ;; Cleanup deletes the file and clears the list
-            (claude-code-ide--cleanup-pasted-images)
-            (should-not (file-exists-p path))
-            (should-not claude-code-ide--pasted-image-files)))))))
+;;; Tests for Completion Notifications (Phase 3 port)
 
 (ert-deftest claude-code-ide-test-notify ()
   "Test notification dispatch respects the enable flag."

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -2759,20 +2759,6 @@ have completed before cleanup.  Waits up to 5 seconds."
                                                        (with-current-buffer buf (set-buffer-modified-p nil))
                                                        (kill-buffer buf))))))))
 
-(ert-deftest claude-code-ide-test-keepalive-init ()
-  "Test keepalive ping starts only when enabled."
-  (let ((started nil))
-    (cl-letf (((symbol-function 'claude-code-ide-mcp--start-ping-timer)
-               (lambda (_session) (setq started t))))
-      (let ((claude-code-ide-enable-keepalive nil)
-            (session (make-claude-code-ide-mcp-session :project-dir "/tmp/")))
-        (claude-code-ide-mcp--handle-initialize 1 nil session)
-        (should-not started))
-      (let ((claude-code-ide-enable-keepalive t)
-            (session (make-claude-code-ide-mcp-session :project-dir "/tmp/")))
-        (claude-code-ide-mcp--handle-initialize 1 nil session)
-        (should started)))))
-
 (ert-deftest claude-code-ide-test-toggle-debug ()
   "Test the debug logging toggle command.
 The test suite mocks the debug module, so load the real file to test the

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -2501,6 +2501,157 @@ have completed before cleanup.  Waits up to 5 seconds."
           (should (equal (plist-get file-path-arg :description)
                          "Path to the file to analyze for symbols")))))))
 
+;;; Tests for Terminal UX Commands (Phase 2 port)
+
+(ert-deftest claude-code-ide-test-format-file-reference ()
+  "Test @file:line reference formatting."
+  (with-temp-buffer
+    (insert "a\nb\nc\n")
+    (goto-char (point-min))
+    (setq buffer-file-name "/tmp/foo.el")
+    (should (equal (claude-code-ide--format-file-reference) "@/tmp/foo.el:1"))
+    (should (equal (claude-code-ide--format-file-reference nil 2 5) "@/tmp/foo.el:2-5"))
+    (should (equal (claude-code-ide--format-file-reference "/x/y.el" 3) "@/x/y.el:3"))
+    (set-buffer-modified-p nil))
+  ;; No file -> nil
+  (with-temp-buffer
+    (should-not (claude-code-ide--format-file-reference))))
+
+(ert-deftest claude-code-ide-test-format-errors-at-point ()
+  "Test diagnostic extraction at point via help-at-pt fallback."
+  (cl-letf (((symbol-function 'help-at-pt-kbd-string) (lambda () nil)))
+    (should-not (claude-code-ide--format-errors-at-point)))
+  (cl-letf (((symbol-function 'help-at-pt-kbd-string) (lambda () "boom error")))
+    (should (equal (claude-code-ide--format-errors-at-point) "boom error"))))
+
+(ert-deftest claude-code-ide-test-send-region ()
+  "Test send-region builds the correct text."
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'claude-code-ide--send-text)
+               (lambda (text) (setq sent text) nil)))
+      ;; With an active region
+      (with-temp-buffer
+        (insert "Hello\nWorld")
+        (goto-char (point-min))
+        (set-mark (point))
+        (goto-char (point-max))
+        (let ((transient-mark-mode t))
+          (activate-mark)
+          (claude-code-ide-send-region))
+        (should (equal sent "Hello\nWorld")))
+      ;; No region -> whole buffer
+      (setq sent nil)
+      (with-temp-buffer
+        (insert "Whole buffer")
+        (claude-code-ide-send-region)
+        (should (equal sent "Whole buffer"))))))
+
+(ert-deftest claude-code-ide-test-send-with-context ()
+  "Test send-with-context appends an @file:line reference."
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'claude-code-ide--send-text)
+               (lambda (text) (setq sent text) nil))
+              ((symbol-function 'read-string) (lambda (&rest _) "do something")))
+      (with-temp-buffer
+        (insert "a\nb\nc")
+        (goto-char (point-min))
+        (setq buffer-file-name "/tmp/ctx.el")
+        (claude-code-ide-send-with-context)
+        (set-buffer-modified-p nil)
+        (should (string-prefix-p "do something" sent))
+        (should (string-match-p "@/tmp/ctx.el:1" sent))))))
+
+(ert-deftest claude-code-ide-test-send-buffer-file ()
+  "Test send-buffer-file sends the buffer's file reference."
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'claude-code-ide--send-text)
+               (lambda (text) (setq sent text) nil)))
+      (with-temp-buffer
+        (insert "x")
+        (goto-char (point-min))
+        (setq buffer-file-name "/tmp/bf.el")
+        (claude-code-ide-send-buffer-file)
+        (set-buffer-modified-p nil)
+        (should (equal sent "@/tmp/bf.el:1")))
+      ;; No file -> user-error
+      (with-temp-buffer
+        (should-error (claude-code-ide-send-buffer-file) :type 'user-error)))))
+
+(ert-deftest claude-code-ide-test-send-file ()
+  "Test send-file injects an @path reference."
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'claude-code-ide--send-text)
+               (lambda (text) (setq sent text) nil)))
+      (claude-code-ide-send-file "/tmp/some/file.txt")
+      (should (equal sent "@/tmp/some/file.txt")))))
+
+(ert-deftest claude-code-ide-test-fix-error-at-point ()
+  "Test fix-error-at-point only sends when a diagnostic is present."
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'claude-code-ide--send-text)
+               (lambda (text) (setq sent text) nil)))
+      ;; No error -> nothing sent
+      (cl-letf (((symbol-function 'claude-code-ide--format-errors-at-point)
+                 (lambda () nil)))
+        (with-temp-buffer
+          (claude-code-ide-fix-error-at-point)
+          (should-not sent)))
+      ;; Error present -> sent text includes it
+      (cl-letf (((symbol-function 'claude-code-ide--format-errors-at-point)
+                 (lambda () "undefined var x")))
+        (with-temp-buffer
+          (insert "code")
+          (setq buffer-file-name "/tmp/err.el")
+          (claude-code-ide-fix-error-at-point)
+          (set-buffer-modified-p nil)
+          (should (string-match-p "undefined var x" sent)))))))
+
+(ert-deftest claude-code-ide-test-send-numbered ()
+  "Test numbered menu selection commands."
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'claude-code-ide--send-text)
+               (lambda (text) (setq sent text) nil)))
+      (claude-code-ide-send-1) (should (equal sent "1"))
+      (claude-code-ide-send-2) (should (equal sent "2"))
+      (claude-code-ide-send-3) (should (equal sent "3")))))
+
+(ert-deftest claude-code-ide-test-terminal-quick-keys ()
+  "Test return, cycle-mode, and fork dispatch to the terminal."
+  (let ((sent-strings '()) (returns 0) (escapes 0)
+        (bufname "*claude-test-term*"))
+    (get-buffer-create bufname)
+    (unwind-protect
+        (cl-letf (((symbol-function 'claude-code-ide--get-buffer-name)
+                   (lambda (&rest _) bufname))
+                  ((symbol-function 'claude-code-ide--terminal-send-string)
+                   (lambda (s) (push s sent-strings)))
+                  ((symbol-function 'claude-code-ide--terminal-send-return)
+                   (lambda () (cl-incf returns)))
+                  ((symbol-function 'claude-code-ide--terminal-send-escape)
+                   (lambda () (cl-incf escapes))))
+          (claude-code-ide-send-return)
+          (should (= returns 1))
+          (claude-code-ide-cycle-mode)
+          (should (member "\e[Z" sent-strings))
+          (claude-code-ide-fork)
+          (should (= escapes 2)))
+      (kill-buffer bufname))))
+
+(ert-deftest claude-code-ide-test-toggle-read-only-mode ()
+  "Test read-only mode toggles its buffer-local state."
+  (let ((states '()) (bufname "*claude-test-term2*"))
+    (get-buffer-create bufname)
+    (unwind-protect
+        (cl-letf (((symbol-function 'claude-code-ide--get-buffer-name)
+                   (lambda (&rest _) bufname))
+                  ((symbol-function 'claude-code-ide--terminal-set-read-only)
+                   (lambda (enable) (push enable states))))
+          (claude-code-ide-toggle-read-only-mode)
+          (claude-code-ide-toggle-read-only-mode)
+          ;; First call enables, second disables
+          (should (equal (reverse states) '(t nil))))
+      (kill-buffer bufname))))
+
 (provide 'claude-code-ide-tests)
 
 ;; Local Variables:

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -2722,6 +2722,100 @@ have completed before cleanup.  Waits up to 5 seconds."
         (should (= notified 1))
         (should (= orig-calls 3))))))
 
+;;; Tests for Diff Pluggability and Polish (Phase 4 port)
+
+(ert-deftest claude-code-ide-test-open-diff-dispatch ()
+  "Test openDiff routes to the configured backend."
+  (let ((called nil)
+        (session (make-claude-code-ide-mcp-session
+                  :project-dir "/tmp/"
+                  :active-diffs (make-hash-table :test 'equal))))
+    (cl-letf (((symbol-function 'claude-code-ide-mcp--find-session-for-file)
+               (lambda (_f) session))
+              ((symbol-function 'claude-code-ide-mcp--open-diff-simple)
+               (lambda (&rest _) (setq called 'simple) '((deferred . t))))
+              ((symbol-function 'claude-code-ide-mcp--open-diff-ediff)
+               (lambda (&rest _) (setq called 'ediff) '((deferred . t)))))
+      (let ((claude-code-ide-diff-tool 'simple)
+            (claude-code-ide-switch-tab-on-ediff nil))
+        (claude-code-ide-mcp-handle-open-diff
+         '((old_file_path . "/tmp/x") (new_file_path . "/tmp/x")
+           (new_file_contents . "c") (tab_name . "t")))
+        (should (eq called 'simple)))
+      (let ((claude-code-ide-diff-tool 'ediff)
+            (claude-code-ide-switch-tab-on-ediff nil))
+        (claude-code-ide-mcp-handle-open-diff
+         '((old_file_path . "/tmp/x") (new_file_path . "/tmp/x")
+           (new_file_contents . "c") (tab_name . "t")))
+        (should (eq called 'ediff))))))
+
+(ert-deftest claude-code-ide-test-simple-diff-accept-reject ()
+  "Test the simple diff backend registers, accepts, and rejects."
+  (let ((completed nil))
+    (cl-letf (((symbol-function 'diff-no-select)
+               (lambda (&rest _) (get-buffer-create "*claude-diff: difftab*")))
+              ((symbol-function 'claude-code-ide-mcp-complete-deferred)
+               (lambda (_session method result &optional key)
+                 (setq completed (list method result key)))))
+      (claude-code-ide-mcp-tests--with-temp-file test-file "old 1\nold 2\n"
+                                                 (let ((session (make-claude-code-ide-mcp-session
+                                                                 :project-dir "/tmp/"
+                                                                 :active-diffs (make-hash-table :test 'equal)
+                                                                 :deferred (make-hash-table :test 'equal))))
+                                                   (unwind-protect
+                                                       (progn
+                                                         ;; Accept path
+                                                         (let ((result (claude-code-ide-mcp--open-diff-simple
+                                                                        test-file test-file "new 1\nnew 2\n" "difftab" session)))
+                                                           (should (alist-get 'deferred result))
+                                                           (should (equal (alist-get 'unique-key result) "difftab"))
+                                                           (should (gethash "difftab" (claude-code-ide-mcp-session-active-diffs session))))
+                                                         (claude-code-ide-mcp--simple-diff-accept "difftab" session)
+                                                         (should (equal (car completed) "openDiff"))
+                                                         (should (equal (alist-get 'text (car (nth 1 completed))) "FILE_SAVED"))
+                                                         (should (string-match-p "new 1" (alist-get 'text (cadr (nth 1 completed)))))
+                                                         (should-not (gethash "difftab" (claude-code-ide-mcp-session-active-diffs session)))
+                                                         ;; Reject path
+                                                         (setq completed nil)
+                                                         (claude-code-ide-mcp--open-diff-simple
+                                                          test-file test-file "new content" "difftab2" session)
+                                                         (claude-code-ide-mcp--simple-diff-reject "difftab2" session)
+                                                         (should (equal (alist-get 'text (car (nth 1 completed))) "DIFF_REJECTED"))
+                                                         (should-not (gethash "difftab2" (claude-code-ide-mcp-session-active-diffs session))))
+                                                     (when-let ((buf (find-buffer-visiting test-file)))
+                                                       (with-current-buffer buf (set-buffer-modified-p nil))
+                                                       (kill-buffer buf))))))))
+
+(ert-deftest claude-code-ide-test-keepalive-init ()
+  "Test keepalive ping starts only when enabled."
+  (let ((started nil))
+    (cl-letf (((symbol-function 'claude-code-ide-mcp--start-ping-timer)
+               (lambda (_session) (setq started t))))
+      (let ((claude-code-ide-enable-keepalive nil)
+            (session (make-claude-code-ide-mcp-session :project-dir "/tmp/")))
+        (claude-code-ide-mcp--handle-initialize 1 nil session)
+        (should-not started))
+      (let ((claude-code-ide-enable-keepalive t)
+            (session (make-claude-code-ide-mcp-session :project-dir "/tmp/")))
+        (claude-code-ide-mcp--handle-initialize 1 nil session)
+        (should started)))))
+
+(ert-deftest claude-code-ide-test-toggle-debug ()
+  "Test the debug logging toggle command.
+The test suite mocks the debug module, so load the real file to test the
+real command, then restore the mock for the remaining tests."
+  (let ((mock-debug (symbol-function 'claude-code-ide-debug)))
+    (unwind-protect
+        (progn
+          (load (expand-file-name "claude-code-ide-debug.el") nil t)
+          (let ((claude-code-ide-debug nil))
+            (claude-code-ide-toggle-debug)
+            (should claude-code-ide-debug)
+            (claude-code-ide-toggle-debug)
+            (should-not claude-code-ide-debug)))
+      ;; Restore the mock so later tests are unaffected
+      (fset 'claude-code-ide-debug mock-debug))))
+
 (provide 'claude-code-ide-tests)
 
 ;; Local Variables:

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -1249,6 +1249,164 @@ have completed before cleanup.  Waits up to 5 seconds."
   (should-error (claude-code-ide-mcp-handle-close-tab '((path . "/nonexistent/file")))
                 :type 'mcp-error))
 
+;;; Tests for IDE State Tools (Phase 1 port)
+
+(ert-deftest claude-code-ide-test-mcp-get-current-selection-tool ()
+  "Test the getCurrentSelection tool handler."
+  ;; With an active selection
+  (claude-code-ide-mcp-tests--with-temp-buffer "Line 1\nLine 2\nLine 3"
+                                               (goto-char (point-min))
+                                               (set-mark (point))
+                                               (forward-line 2)
+                                               (let ((transient-mark-mode t))
+                                                 (activate-mark)
+                                                 (let* ((result (claude-code-ide-mcp-handle-get-current-selection nil))
+                                                        (text (alist-get 'text (car result)))
+                                                        (data (json-read-from-string text)))
+                                                   (should (equal (alist-get 'type (car result)) "text"))
+                                                   (should (equal (alist-get 'text data) "Line 1\nLine 2\n"))
+                                                   (should (eq (alist-get 'isEmpty (alist-get 'selection data)) :json-false)))))
+  ;; Without a selection - isEmpty should be true
+  (claude-code-ide-mcp-tests--with-temp-buffer "Test"
+                                               (let* ((result (claude-code-ide-mcp-handle-get-current-selection nil))
+                                                      (data (json-read-from-string (alist-get 'text (car result)))))
+                                                 (should (equal (alist-get 'text data) ""))
+                                                 (should (eq (alist-get 'isEmpty (alist-get 'selection data)) t)))))
+
+(ert-deftest claude-code-ide-test-mcp-get-latest-selection-tool ()
+  "Test the getLatestSelection tool handler."
+  (claude-code-ide-mcp-tests--with-temp-file test-file "Alpha\nBeta\nGamma"
+                                             (let ((buf (find-file-noselect test-file)))
+                                               (unwind-protect
+                                                   (let ((transient-mark-mode t))
+                                                     (with-current-buffer buf
+                                                       (goto-char (point-min))
+                                                       (set-mark (point))
+                                                       (forward-line 1)
+                                                       (activate-mark))
+                                                     (let* ((result (claude-code-ide-mcp-handle-get-latest-selection nil))
+                                                            (data (json-read-from-string (alist-get 'text (car result)))))
+                                                       (should (equal (alist-get 'text data) "Alpha\n"))))
+                                                 (when (buffer-live-p buf) (kill-buffer buf))))))
+
+(ert-deftest claude-code-ide-test-mcp-get-open-editors ()
+  "Test the getOpenEditors tool handler."
+  (claude-code-ide-mcp-tests--with-temp-file test-file "content"
+                                             (let ((buf (find-file-noselect test-file)))
+                                               (unwind-protect
+                                                   (let* ((result (claude-code-ide-mcp-handle-get-open-editors nil))
+                                                          (data (json-read-from-string (alist-get 'text (car result))))
+                                                          (editors (alist-get 'editors data)))
+                                                     (should (vectorp editors))
+                                                     (should (seq-find (lambda (e) (equal (alist-get 'path e) test-file))
+                                                                       editors)))
+                                                 (when (buffer-live-p buf) (kill-buffer buf))))))
+
+(ert-deftest claude-code-ide-test-mcp-get-workspace-folders ()
+  "Test the getWorkspaceFolders tool handler."
+  (let* ((session (make-claude-code-ide-mcp-session :project-dir "/tmp/claude-proj-xyz/"))
+         (result (claude-code-ide-mcp-handle-get-workspace-folders nil session))
+         (data (json-read-from-string (alist-get 'text (car result))))
+         (folders (alist-get 'folders data)))
+    (should (vectorp folders))
+    (should (seq-find (lambda (f) (string-match-p "claude-proj-xyz" (alist-get 'uri f)))
+                      folders))))
+
+(ert-deftest claude-code-ide-test-mcp-check-document-dirty ()
+  "Test the checkDocumentDirty tool handler."
+  (claude-code-ide-mcp-tests--with-temp-file test-file "content"
+                                             (let ((buf (find-file-noselect test-file)))
+                                               (unwind-protect
+                                                   (progn
+                                                     ;; Clean buffer
+                                                     (let ((data (json-read-from-string
+                                                                  (alist-get 'text (car (claude-code-ide-mcp-handle-check-document-dirty
+                                                                                         `((filePath . ,test-file))))))))
+                                                       (should (eq (alist-get 'isDirty data) :json-false)))
+                                                     ;; Modify, then check via file:// URI
+                                                     (with-current-buffer buf
+                                                       (goto-char (point-max))
+                                                       (insert "more"))
+                                                     (let ((data (json-read-from-string
+                                                                  (alist-get 'text (car (claude-code-ide-mcp-handle-check-document-dirty
+                                                                                         `((uri . ,(concat "file://" test-file)))))))))
+                                                       (should (eq (alist-get 'isDirty data) t))))
+                                                 (when (buffer-live-p buf)
+                                                   (with-current-buffer buf (set-buffer-modified-p nil))
+                                                   (kill-buffer buf)))))
+  ;; Missing parameter
+  (should-error (claude-code-ide-mcp-handle-check-document-dirty '())
+                :type 'mcp-error))
+
+(ert-deftest claude-code-ide-test-mcp-save-document ()
+  "Test the saveDocument tool handler."
+  (claude-code-ide-mcp-tests--with-temp-file test-file "content"
+                                             (let ((buf (find-file-noselect test-file)))
+                                               (unwind-protect
+                                                   (progn
+                                                     (with-current-buffer buf
+                                                       (goto-char (point-max))
+                                                       (insert "appended"))
+                                                     (let ((data (json-read-from-string
+                                                                  (alist-get 'text (car (claude-code-ide-mcp-handle-save-document
+                                                                                         `((filePath . ,test-file))))))))
+                                                       (should (eq (alist-get 'saved data) t))
+                                                       (should-not (buffer-modified-p buf))))
+                                                 (when (buffer-live-p buf) (kill-buffer buf)))))
+  ;; File not open returns saved:false
+  (let ((data (json-read-from-string
+               (alist-get 'text (car (claude-code-ide-mcp-handle-save-document
+                                      '((filePath . "/nonexistent/file-xyz"))))))))
+    (should (eq (alist-get 'saved data) :json-false)))
+  ;; Missing parameter
+  (should-error (claude-code-ide-mcp-handle-save-document '())
+                :type 'mcp-error))
+
+(ert-deftest claude-code-ide-test-mcp-arg-file-path ()
+  "Test file path extraction from tool arguments."
+  (should (equal (claude-code-ide-mcp--arg-file-path '((filePath . "/a/b.el"))) "/a/b.el"))
+  (should (equal (claude-code-ide-mcp--arg-file-path '((uri . "file:///a/b.el"))) "/a/b.el"))
+  (should (equal (claude-code-ide-mcp--arg-file-path '((path . "/a/b.el"))) "/a/b.el"))
+  (should-not (claude-code-ide-mcp--arg-file-path '())))
+
+;;; Tests for MCP Resources (Phase 1 port)
+
+(ert-deftest claude-code-ide-test-mcp-mime-type ()
+  "Test MIME type resolution by extension."
+  (should (equal (claude-code-ide-mcp--get-mime-type "foo.el") "text/x-elisp"))
+  (should (equal (claude-code-ide-mcp--get-mime-type "foo.py") "text/x-python"))
+  (should (equal (claude-code-ide-mcp--get-mime-type "foo.json") "application/json"))
+  (should (equal (claude-code-ide-mcp--get-mime-type "foo.unknownext") "text/plain"))
+  (should (equal (claude-code-ide-mcp--get-mime-type "noextension") "text/plain")))
+
+(ert-deftest claude-code-ide-test-mcp-resources-list ()
+  "Test that resources/list includes open file buffers."
+  (claude-code-ide-mcp-tests--with-temp-file test-file "data"
+                                             (let ((buf (find-file-noselect test-file)))
+                                               (unwind-protect
+                                                   (let* ((response (claude-code-ide-mcp--handle-resources-list 1 nil))
+                                                          (resources (alist-get 'resources (alist-get 'result response))))
+                                                     (should (vectorp resources))
+                                                     (should (seq-find (lambda (r)
+                                                                         (equal (alist-get 'uri r)
+                                                                                (concat "file://" test-file)))
+                                                                       resources)))
+                                                 (when (buffer-live-p buf) (kill-buffer buf))))))
+
+(ert-deftest claude-code-ide-test-mcp-resources-read ()
+  "Test reading a resource by file:// URI."
+  (claude-code-ide-mcp-tests--with-temp-file test-file "hello resources"
+                                             (let* ((uri (concat "file://" test-file))
+                                                    (response (claude-code-ide-mcp--handle-resources-read 1 `((uri . ,uri))))
+                                                    (contents (alist-get 'contents (alist-get 'result response)))
+                                                    (entry (aref contents 0)))
+                                               (should (equal (alist-get 'uri entry) uri))
+                                               (should (equal (alist-get 'text entry) "hello resources"))
+                                               (should (equal (alist-get 'mimeType entry) "text/plain"))))
+  ;; Non-existent resource returns an error response
+  (let ((response (claude-code-ide-mcp--handle-resources-read 1 '((uri . "file:///nonexistent/xyz")))))
+    (should (alist-get 'error response))))
+
 (ert-deftest claude-code-ide-test-mcp-tool-registry ()
   "Test that all tools are properly registered."
   ;; Build expected tools list dynamically based on configuration

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -2652,6 +2652,76 @@ have completed before cleanup.  Waits up to 5 seconds."
           (should (equal (reverse states) '(t nil))))
       (kill-buffer bufname))))
 
+;;; Tests for Image Paste and Notifications (Phase 3 port)
+
+(ert-deftest claude-code-ide-test-image-extension-for-mimetype ()
+  "Test MIME type to file extension mapping."
+  (should (equal (claude-code-ide--image-extension-for-mimetype "image/png") ".png"))
+  (should (equal (claude-code-ide--image-extension-for-mimetype 'image/jpeg) ".jpg"))
+  (should (equal (claude-code-ide--image-extension-for-mimetype "image/gif") ".gif"))
+  (should (equal (claude-code-ide--image-extension-for-mimetype "image/webp") ".webp"))
+  (should (equal (claude-code-ide--image-extension-for-mimetype "image/unknown") ".png")))
+
+(ert-deftest claude-code-ide-test-image-yank-media-handler ()
+  "Test image paste writes a temp file and injects an @path reference."
+  (let ((sent nil))
+    (cl-letf (((symbol-function 'claude-code-ide--terminal-send-string)
+               (lambda (s) (setq sent s))))
+      (with-temp-buffer
+        (let ((claude-code-ide-image-paste-directory temporary-file-directory)
+              (claude-code-ide-image-paste-cleanup-on-kill t))
+          (should (claude-code-ide--image-yank-media-handler "image/png" "fakedata"))
+          (should (= (length claude-code-ide--pasted-image-files) 1))
+          (let ((path (car claude-code-ide--pasted-image-files)))
+            (should (file-exists-p path))
+            (should (string-suffix-p ".png" path))
+            (should (equal sent (concat "@" path " ")))
+            ;; Cleanup deletes the file and clears the list
+            (claude-code-ide--cleanup-pasted-images)
+            (should-not (file-exists-p path))
+            (should-not claude-code-ide--pasted-image-files)))))))
+
+(ert-deftest claude-code-ide-test-notify ()
+  "Test notification dispatch respects the enable flag."
+  (let ((called nil))
+    (cl-letf (((symbol-function 'claude-code-ide-default-notification)
+               (lambda (title msg) (setq called (list title msg)))))
+      (let ((claude-code-ide-enable-notifications t)
+            (claude-code-ide-notification-function
+             #'claude-code-ide-default-notification))
+        (claude-code-ide--notify)
+        (should called))
+      (setq called nil)
+      (let ((claude-code-ide-enable-notifications nil)
+            (claude-code-ide-notification-function
+             #'claude-code-ide-default-notification))
+        (claude-code-ide--notify)
+        (should-not called)))))
+
+(ert-deftest claude-code-ide-test-vterm-bell-detector ()
+  "Test the bell detector notifies on BEL but ignores OSC title sequences."
+  (let ((orig-calls 0) (notified 0)
+        (claude-code-ide-enable-notifications t))
+    (cl-letf (((symbol-function 'claude-code-ide--notify)
+               (lambda (&rest _) (cl-incf notified)))
+              ((symbol-function 'claude-code-ide--session-buffer-p)
+               (lambda (_buf) t))
+              ((symbol-function 'process-buffer)
+               (lambda (_p) (current-buffer))))
+      (let ((orig (lambda (_p _i) (cl-incf orig-calls))))
+        ;; Bell present -> notify and pass through
+        (claude-code-ide--vterm-bell-detector orig nil "hello\007world")
+        (should (= notified 1))
+        (should (= orig-calls 1))
+        ;; OSC title bell -> no notify, still passes through
+        (claude-code-ide--vterm-bell-detector orig nil "\033]0;title\007")
+        (should (= notified 1))
+        (should (= orig-calls 2))
+        ;; No bell -> no notify, passes through
+        (claude-code-ide--vterm-bell-detector orig nil "plain text")
+        (should (= notified 1))
+        (should (= orig-calls 3))))))
+
 (provide 'claude-code-ide-tests)
 
 ;; Local Variables:

--- a/claude-code-ide-transient.el
+++ b/claude-code-ide-transient.el
@@ -41,6 +41,18 @@
 (declare-function claude-code-ide-send-prompt "claude-code-ide" ())
 (declare-function claude-code-ide-send-escape "claude-code-ide" ())
 (declare-function claude-code-ide-insert-newline "claude-code-ide" ())
+(declare-function claude-code-ide-send-region "claude-code-ide" (&optional arg))
+(declare-function claude-code-ide-send-with-context "claude-code-ide" ())
+(declare-function claude-code-ide-send-buffer-file "claude-code-ide" ())
+(declare-function claude-code-ide-send-file "claude-code-ide" (file))
+(declare-function claude-code-ide-fix-error-at-point "claude-code-ide" ())
+(declare-function claude-code-ide-send-return "claude-code-ide" ())
+(declare-function claude-code-ide-send-1 "claude-code-ide" ())
+(declare-function claude-code-ide-send-2 "claude-code-ide" ())
+(declare-function claude-code-ide-send-3 "claude-code-ide" ())
+(declare-function claude-code-ide-cycle-mode "claude-code-ide" ())
+(declare-function claude-code-ide-fork "claude-code-ide" ())
+(declare-function claude-code-ide-toggle-read-only-mode "claude-code-ide" ())
 (declare-function claude-code-ide-toggle "claude-code-ide" ())
 (declare-function claude-code-ide-check-status "claude-code-ide" ())
 (declare-function claude-code-ide--ensure-cli "claude-code-ide" ())
@@ -333,8 +345,31 @@ Otherwise, if multiple sessions exist, prompt for selection."
     ("e" "Send escape key" claude-code-ide-send-escape)
     ("n" "Insert newline" claude-code-ide-insert-newline)]
    ["Submenus"
+    ("S" "Send & quick actions" claude-code-ide-send-menu)
     ("C" "Configuration" claude-code-ide-config-menu)
     ("d" "Debugging" claude-code-ide-debug-menu)]])
+
+(transient-define-prefix claude-code-ide-send-menu ()
+  "Send content and quick responses to Claude Code."
+  ["Send to Claude Code"
+   ["Send"
+    ("r" "Region or buffer" claude-code-ide-send-region)
+    ("x" "Command with file/line context" claude-code-ide-send-with-context)
+    ("o" "Current buffer's file" claude-code-ide-send-buffer-file)
+    ("f" "A file" claude-code-ide-send-file)
+    ("p" "Prompt from minibuffer" claude-code-ide-send-prompt)
+    ("i" "Insert selection" claude-code-ide-insert-at-mentioned)
+    ("E" "Fix error at point" claude-code-ide-fix-error-at-point)]
+   ["Quick responses"
+    ("y" "Return (confirm)" claude-code-ide-send-return)
+    ("1" "Select option 1" claude-code-ide-send-1)
+    ("2" "Select option 2" claude-code-ide-send-2)
+    ("3" "Select option 3" claude-code-ide-send-3)
+    ("e" "Escape" claude-code-ide-send-escape)
+    ("n" "Newline" claude-code-ide-insert-newline)
+    ("m" "Cycle mode (Shift-Tab)" claude-code-ide-cycle-mode)
+    ("k" "Fork (jump back)" claude-code-ide-fork)
+    ("z" "Toggle read-only mode" claude-code-ide-toggle-read-only-mode)]])
 
 (transient-define-prefix claude-code-ide-config-menu ()
   "Claude Code configuration menu."

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -92,6 +92,7 @@
 (declare-function eat-term-display-cursor "eat" (terminal))
 (declare-function eat-emacs-mode "eat" ())
 (declare-function eat-semi-char-mode "eat" ())
+(declare-function eat-term-parameter "eat" (terminal parameter))
 (declare-function eat--adjust-process-window-size "eat" (process windows))
 
 ;; External function declarations for ghostel
@@ -220,6 +221,39 @@ resources/read MCP methods.  Set to nil to disable resource sharing."
 Used by `claude-code-ide-send-region' when no region is active and the
 whole buffer would be sent."
   :type 'integer
+  :group 'claude-code-ide)
+
+(defcustom claude-code-ide-enable-image-paste t
+  "Whether to enable image pasting via `yank-media' in Claude buffers.
+When non-nil, pasting an image into the Claude terminal writes it to a
+temporary file and inserts an @path reference at the prompt, which
+Claude's CLI reads natively.  Requires Emacs 29 or later."
+  :type 'boolean
+  :group 'claude-code-ide)
+
+(defcustom claude-code-ide-image-paste-directory
+  (if (file-directory-p "/tmp") "/tmp" temporary-file-directory)
+  "Directory where pasted images are written.
+Defaults to \"/tmp\" when available so the inserted @path stays short."
+  :type 'directory
+  :group 'claude-code-ide)
+
+(defcustom claude-code-ide-image-paste-cleanup-on-kill t
+  "Whether to delete pasted image temp files when the Claude buffer is killed."
+  :type 'boolean
+  :group 'claude-code-ide)
+
+(defcustom claude-code-ide-enable-notifications t
+  "Whether to notify when Claude finishes and is awaiting input.
+Notifications are triggered by the terminal bell that Claude emits when
+it needs attention.  See `claude-code-ide-notification-function'."
+  :type 'boolean
+  :group 'claude-code-ide)
+
+(defcustom claude-code-ide-notification-function #'claude-code-ide-default-notification
+  "Function called to notify the user that Claude is waiting.
+It is called with two string arguments: TITLE and MESSAGE."
+  :type 'function
   :group 'claude-code-ide)
 
 (defcustom claude-code-ide-switch-tab-on-ediff t
@@ -468,7 +502,10 @@ cursor management, and process buffering for superior user experience."
       (process-put proc 'read-output-max 4096)))
   ;; Set up rendering optimization
   (when claude-code-ide-vterm-anti-flicker
-    (advice-add 'vterm--filter :around #'claude-code-ide--vterm-smart-renderer)))
+    (advice-add 'vterm--filter :around #'claude-code-ide--vterm-smart-renderer))
+  ;; Set up bell-based completion notifications
+  (when claude-code-ide-enable-notifications
+    (advice-add 'vterm--filter :around #'claude-code-ide--vterm-bell-detector)))
 
 
 ;;; Terminal Backend Abstraction
@@ -615,6 +652,117 @@ This function binds:
   "Check if BUFFER belongs to a Claude Code session."
   (when-let ((name (if (stringp buffer) buffer (buffer-name buffer))))
     (string-prefix-p "*claude-code[" name)))
+
+;;; Image Pasting
+
+(defconst claude-code-ide--image-mime-extensions
+  '(("image/png" . ".png")
+    ("image/jpeg" . ".jpg")
+    ("image/jpg" . ".jpg")
+    ("image/gif" . ".gif")
+    ("image/webp" . ".webp")
+    ("image/bmp" . ".bmp"))
+  "Alist mapping image MIME-type prefix to file extension.")
+
+(defvar-local claude-code-ide--pasted-image-files nil
+  "List of temp image files pasted into this Claude buffer, for cleanup.")
+
+(defun claude-code-ide--image-extension-for-mimetype (mimetype)
+  "Return the file extension (including the dot) for MIMETYPE.
+MIMETYPE may be a symbol or a string.  Falls back to \".png\"."
+  (let* ((str (if (symbolp mimetype) (symbol-name mimetype) mimetype))
+         (match (seq-find (lambda (pair) (string-prefix-p (car pair) str))
+                          claude-code-ide--image-mime-extensions)))
+    (if match (cdr match) ".png")))
+
+(defun claude-code-ide--image-yank-media-handler (mimetype data)
+  "Handle an image paste in a Claude buffer.
+MIMETYPE is the MIME type (string or symbol); DATA is the raw bytes.
+Writes DATA to a temp file and injects an @path reference at the prompt."
+  (let* ((ext (claude-code-ide--image-extension-for-mimetype mimetype))
+         (temporary-file-directory claude-code-ide-image-paste-directory)
+         (path (make-temp-file "claude-image-" nil ext))
+         (coding-system-for-write 'binary))
+    (with-temp-file path (insert data))
+    (push path claude-code-ide--pasted-image-files)
+    (claude-code-ide--terminal-send-string (concat "@" path " "))
+    (message "Pasted image as %s" path)
+    t))
+
+(defun claude-code-ide--cleanup-pasted-images ()
+  "Delete temp image files created by `yank-media' in this buffer."
+  (when claude-code-ide-image-paste-cleanup-on-kill
+    (dolist (file claude-code-ide--pasted-image-files)
+      (when (file-exists-p file)
+        (ignore-errors (delete-file file))))
+    (setq claude-code-ide--pasted-image-files nil)))
+
+(defun claude-code-ide--register-image-yank-media-handler ()
+  "Register an image `yank-media-handler' in the current Claude buffer.
+No-op on Emacs versions without `yank-media-handler' (pre-29)."
+  (when (and claude-code-ide-enable-image-paste
+             (fboundp 'yank-media-handler))
+    (yank-media-handler "image/.*" #'claude-code-ide--image-yank-media-handler)
+    (add-hook 'kill-buffer-hook #'claude-code-ide--cleanup-pasted-images nil t)))
+
+;;; Completion Notifications
+
+(defun claude-code-ide--pulse-modeline ()
+  "Pulse the modeline to provide a visual notification."
+  (invert-face 'mode-line)
+  (run-at-time 0.1 nil
+               (lambda ()
+                 (invert-face 'mode-line)
+                 (run-at-time 0.1 nil
+                              (lambda ()
+                                (invert-face 'mode-line)
+                                (run-at-time 0.1 nil
+                                             (lambda ()
+                                               (invert-face 'mode-line))))))))
+
+(defun claude-code-ide-default-notification (title message)
+  "Default notification: echo TITLE and MESSAGE and pulse the modeline."
+  (message "%s: %s" title message)
+  (claude-code-ide--pulse-modeline))
+
+(defun claude-code-ide--notify (&rest _)
+  "Notify the user that Claude has finished and is awaiting input.
+Accepts and ignores any arguments so it can serve as both a terminal
+`ring-bell-function' and an eat terminal bell parameter."
+  (when claude-code-ide-enable-notifications
+    (funcall claude-code-ide-notification-function
+             "Claude Code" "Waiting for your response")))
+
+(defun claude-code-ide--vterm-bell-detector (orig-fun process input)
+  "Detect bell characters in vterm output and trigger notifications.
+ORIG-FUN is the original `vterm--filter'.  PROCESS is the vterm process.
+INPUT is the terminal output string.  Bells inside OSC title sequences
+are ignored."
+  (when (and claude-code-ide-enable-notifications
+             (string-match-p "\007" input)
+             (claude-code-ide--session-buffer-p (process-buffer process))
+             (not (string-match-p "]0;.*\007" input)))
+    (claude-code-ide--notify))
+  (funcall orig-fun process input))
+
+(defun claude-code-ide--setup-terminal-extras ()
+  "Set up image pasting and bell notifications in the current Claude buffer.
+Assumes the current buffer is the Claude terminal buffer."
+  (claude-code-ide--register-image-yank-media-handler)
+  (when claude-code-ide-enable-notifications
+    (cond
+     ((eq claude-code-ide-terminal-backend 'vterm)
+      ;; vterm notifications are handled by the bell-detector filter advice,
+      ;; installed in `claude-code-ide--configure-vterm-buffer'.
+      nil)
+     ((eq claude-code-ide-terminal-backend 'eat)
+      ;; eat invokes the terminal's ring-bell-function parameter on BEL.
+      (when (and (bound-and-true-p eat-terminal) (fboundp 'eat-term-parameter))
+        (eval '(setf (eat-term-parameter eat-terminal 'ring-bell-function)
+                     #'claude-code-ide--notify)
+              t)))
+     ((eq claude-code-ide-terminal-backend 'ghostel)
+      (setq-local ring-bell-function #'claude-code-ide--notify)))))
 
 (defun claude-code-ide--terminal-reflow-filter (original-fn &rest args)
   "Filter terminal reflows to prevent height-only resize triggers.
@@ -774,6 +922,10 @@ If `claude-code-ide-focus-on-open' is non-nil, the window is selected."
                      claude-code-ide-vterm-anti-flicker
                      (= (hash-table-count claude-code-ide--processes) 0))
             (advice-remove 'vterm--filter #'claude-code-ide--vterm-smart-renderer))
+          ;; Remove vterm bell detector if no sessions remain
+          (when (and (eq claude-code-ide-terminal-backend 'vterm)
+                     (= (hash-table-count claude-code-ide--processes) 0))
+            (advice-remove 'vterm--filter #'claude-code-ide--vterm-bell-detector))
           ;; Stop MCP server for this project directory
           (claude-code-ide-mcp-stop-session directory)
           ;; Notify MCP tools server about session end with session ID
@@ -1118,6 +1270,8 @@ This function handles:
                             nil t)
                   ;; Set up terminal keybindings
                   (claude-code-ide--setup-terminal-keybindings)
+                  ;; Set up image pasting and bell notifications
+                  (claude-code-ide--setup-terminal-extras)
                   ;; Add terminal-specific exit hooks
                   (cond
                    ((eq claude-code-ide-terminal-backend 'vterm)

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -208,6 +208,24 @@ display diffs in the terminal instead."
   :type 'boolean
   :group 'claude-code-ide)
 
+(defcustom claude-code-ide-diff-tool 'ediff
+  "Which backend to use for the IDE diff viewer.
+- `ediff' (default): an interactive ediff session; edits made to the new
+  buffer are sent back to Claude when you accept.
+- `simple': a read-only `diff-mode' buffer where \\`y' accepts the change
+  and \\`q' rejects it.
+Diffs are enabled or disabled with `claude-code-ide-use-ide-diff'."
+  :type '(choice (const :tag "Ediff (interactive)" ediff)
+                 (const :tag "Simple (read-only diff-mode)" simple))
+  :group 'claude-code-ide)
+
+(defcustom claude-code-ide-enable-keepalive nil
+  "Whether to send periodic WebSocket pings to keep the connection alive.
+Disabled by default.  Enable if long-idle sessions drop their connection;
+pings are sent every `claude-code-ide-mcp-ping-interval' seconds."
+  :type 'boolean
+  :group 'claude-code-ide)
+
 (defcustom claude-code-ide-enable-resources t
   "Whether to expose Emacs files to Claude Code as MCP resources.
 When non-nil (default), Claude Code can list and read open buffers,

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -82,6 +82,7 @@
 (declare-function vterm-send-string "vterm" (string))
 (declare-function vterm-send-escape "vterm" ())
 (declare-function vterm-send-return "vterm" ())
+(declare-function vterm-copy-mode "vterm" (&optional arg))
 (declare-function vterm--window-adjust-process-window-size "vterm" (&optional frame))
 
 ;; External function declarations for eat
@@ -89,6 +90,8 @@
 (declare-function eat-exec "eat" (buffer name command startfile &rest switches))
 (declare-function eat-term-send-string "eat" (terminal string))
 (declare-function eat-term-display-cursor "eat" (terminal))
+(declare-function eat-emacs-mode "eat" ())
+(declare-function eat-semi-char-mode "eat" ())
 (declare-function eat--adjust-process-window-size "eat" (process windows))
 
 ;; External function declarations for ghostel
@@ -210,6 +213,13 @@ When non-nil (default), Claude Code can list and read open buffers,
 recent files, and project files via the resources/list and
 resources/read MCP methods.  Set to nil to disable resource sharing."
   :type 'boolean
+  :group 'claude-code-ide)
+
+(defcustom claude-code-ide-large-buffer-threshold 100000
+  "Buffer size in characters above which sending requires confirmation.
+Used by `claude-code-ide-send-region' when no region is active and the
+whole buffer would be sent."
+  :type 'integer
   :group 'claude-code-ide)
 
 (defcustom claude-code-ide-switch-tab-on-ediff t
@@ -562,12 +572,14 @@ This function binds:
    ((eq claude-code-ide-terminal-backend 'vterm)
     ;; For vterm, we set up local keybindings in vterm-mode-map
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
-    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
+    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape)
+    (local-set-key (kbd "C-c C-r") #'claude-code-ide-toggle-read-only-mode))
    ((eq claude-code-ide-terminal-backend 'eat)
     ;; For eat, we need to modify the semi-char mode map which is the default
     ;; We use local-set-key to make it buffer-local
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
-    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
+    (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape)
+    (local-set-key (kbd "C-c C-r") #'claude-code-ide-toggle-read-only-mode))
    ((eq claude-code-ide-terminal-backend 'ghostel)
     (local-set-key (kbd "S-<return>") #'claude-code-ide-insert-newline)
     (local-set-key (kbd "C-<escape>") #'claude-code-ide-send-escape))
@@ -1226,6 +1238,80 @@ If the buffer is already visible, switch focus to it."
       (claude-code-ide-log "No active Claude Code sessions"))))
 
 ;;;###autoload
+;;; Terminal interaction helpers
+
+(defvar claude-code-ide-command-history nil
+  "History list for commands sent to Claude Code via the minibuffer.")
+
+(defvar-local claude-code-ide--read-only-active nil
+  "Whether read-only/copy mode is active in this Claude terminal buffer.")
+
+(defmacro claude-code-ide--with-terminal-buffer (&rest body)
+  "Execute BODY in the current project's Claude terminal buffer.
+Signals a `user-error' when there is no session for the project."
+  (declare (indent 0))
+  `(let ((buffer-name (claude-code-ide--get-buffer-name)))
+     (if-let ((buffer (get-buffer buffer-name)))
+         (with-current-buffer buffer ,@body)
+       (user-error "No Claude Code session for this project"))))
+
+(defun claude-code-ide--send-text (text)
+  "Send TEXT followed by a return to the current project's Claude terminal.
+Returns the Claude buffer on success, signals a `user-error' otherwise."
+  (claude-code-ide--with-terminal-buffer
+   (claude-code-ide--terminal-send-string text)
+   ;; Small delay to ensure the text is processed before sending return
+   (sit-for 0.1)
+   (claude-code-ide--terminal-send-return)
+   buffer))
+
+(defun claude-code-ide--format-file-reference (&optional file-name line-start line-end)
+  "Format a file reference in the @file:line style.
+FILE-NAME defaults to the current buffer's file.  LINE-START defaults to
+the current line.  LINE-END, when given, formats a line range."
+  (let ((file (or file-name (buffer-file-name)))
+        (start (or line-start (line-number-at-pos nil t))))
+    (when file
+      (if line-end
+          (format "@%s:%d-%d" file start line-end)
+        (format "@%s:%d" file start)))))
+
+(defun claude-code-ide--format-errors-at-point ()
+  "Return a string describing diagnostics at point.
+Tries Flycheck first, then falls back to `help-at-pt' (used by Flymake
+and other systems).  Returns nil when no diagnostics are found."
+  (cond
+   ((and (featurep 'flycheck) (bound-and-true-p flycheck-mode)
+         (fboundp 'flycheck-overlay-errors-at))
+    (let ((errors (flycheck-overlay-errors-at (point))))
+      (when errors
+        (string-trim-right
+         (mapconcat (lambda (err)
+                      (format "%s:%s: %s"
+                              (flycheck-error-filename err)
+                              (flycheck-error-line err)
+                              (flycheck-error-message err)))
+                    errors "\n")))))
+   ((help-at-pt-kbd-string)
+    (substring-no-properties (help-at-pt-kbd-string)))
+   (t nil)))
+
+(defun claude-code-ide--terminal-set-read-only (enable)
+  "Enable or disable read-only/copy mode in the current terminal buffer.
+When ENABLE is non-nil, switch to a navigable read-only mode; otherwise
+return to interactive mode."
+  (cond
+   ((eq claude-code-ide-terminal-backend 'vterm)
+    (if enable (vterm-copy-mode 1) (vterm-copy-mode -1)))
+   ((eq claude-code-ide-terminal-backend 'eat)
+    (if enable
+        (when (fboundp 'eat-emacs-mode) (eat-emacs-mode))
+      (when (fboundp 'eat-semi-char-mode) (eat-semi-char-mode))))
+   ((eq claude-code-ide-terminal-backend 'ghostel)
+    (user-error "Read-only mode is not supported for the ghostel backend"))
+   (t
+    (error "Unknown terminal backend: %s" claude-code-ide-terminal-backend))))
+
 (defun claude-code-ide-insert-at-mentioned ()
   "Insert selected text into Claude prompt."
   (interactive)
@@ -1280,17 +1366,129 @@ Use this to balance between visual smoothness and raw responsiveness."
 When called interactively, reads a prompt from the minibuffer.
 When called programmatically, sends the given PROMPT string."
   (interactive)
-  (let ((buffer-name (claude-code-ide--get-buffer-name)))
-    (if-let ((buffer (get-buffer buffer-name)))
-        (let ((prompt-to-send (or prompt (read-string "Claude prompt: "))))
-          (when (not (string-empty-p prompt-to-send))
-            (with-current-buffer buffer
-              (claude-code-ide--terminal-send-string prompt-to-send)
-              ;; Small delay to ensure prompt text is processed before sending return
-              (sit-for 0.1)
-              (claude-code-ide--terminal-send-return))
-            (claude-code-ide-debug "Sent prompt to Claude Code: %s" prompt-to-send)))
-      (user-error "No Claude Code session for this project"))))
+  (let ((prompt-to-send (or prompt (read-string "Claude prompt: "))))
+    (unless (string-empty-p prompt-to-send)
+      (claude-code-ide--send-text prompt-to-send)
+      (claude-code-ide-debug "Sent prompt to Claude Code: %s" prompt-to-send))))
+
+;;;###autoload
+(defun claude-code-ide-send-region (&optional arg)
+  "Send the active region to Claude Code.
+If no region is active, send the whole buffer, asking for confirmation
+when it exceeds `claude-code-ide-large-buffer-threshold'.  With prefix
+ARG, prompt for instructions to prepend to the text."
+  (interactive "P")
+  (let* ((text (if (use-region-p)
+                   (buffer-substring-no-properties (region-beginning) (region-end))
+                 (if (and (> (buffer-size) claude-code-ide-large-buffer-threshold)
+                          (not (yes-or-no-p "Buffer is large.  Send anyway? ")))
+                     nil
+                   (buffer-substring-no-properties (point-min) (point-max)))))
+         (instructions (when arg (read-string "Instructions for Claude: ")))
+         (full-text (if (and instructions (not (string-empty-p instructions)))
+                        (format "%s\n\n%s" instructions text)
+                      text)))
+    (when full-text
+      (claude-code-ide--send-text full-text))))
+
+;;;###autoload
+(defun claude-code-ide-send-buffer-file ()
+  "Send a reference to the current buffer's file to Claude Code."
+  (interactive)
+  (let ((ref (claude-code-ide--format-file-reference)))
+    (unless ref
+      (user-error "Current buffer is not visiting a file"))
+    (claude-code-ide--send-text ref)))
+
+;;;###autoload
+(defun claude-code-ide-send-file (file)
+  "Send a reference to FILE to Claude Code.
+Interactively, prompt for the file."
+  (interactive "fSend file to Claude: ")
+  (claude-code-ide--send-text (format "@%s" (expand-file-name file))))
+
+;;;###autoload
+(defun claude-code-ide-send-with-context ()
+  "Read a command and send it with the current file and line as context.
+If a region is active, include its line range."
+  (interactive)
+  (let* ((cmd (read-string "Claude command: " nil 'claude-code-ide-command-history))
+         (file-ref (if (use-region-p)
+                       (claude-code-ide--format-file-reference
+                        nil
+                        (line-number-at-pos (region-beginning) t)
+                        (line-number-at-pos (region-end) t))
+                     (claude-code-ide--format-file-reference)))
+         (full (if file-ref (format "%s\n%s" cmd file-ref) cmd)))
+    (claude-code-ide--send-text full)))
+
+;;;###autoload
+(defun claude-code-ide-fix-error-at-point ()
+  "Ask Claude Code to fix the diagnostic at point.
+Supports Flycheck, Flymake, and any system implementing `help-at-pt'."
+  (interactive)
+  (let ((error-text (claude-code-ide--format-errors-at-point))
+        (file-ref (claude-code-ide--format-file-reference)))
+    (if (not error-text)
+        (message "No errors found at point")
+      (claude-code-ide--send-text
+       (format "Fix this error at %s. Do not run any external linter; just fix the error at point using the context provided in the error message: <%s>"
+               (or file-ref "the current position") error-text)))))
+
+;;;###autoload
+(defun claude-code-ide-send-return ()
+  "Send a lone return to Claude Code (e.g. to confirm a prompt)."
+  (interactive)
+  (claude-code-ide--with-terminal-buffer
+   (claude-code-ide--terminal-send-return)))
+
+;;;###autoload
+(defun claude-code-ide-send-1 ()
+  "Select the first option in a Claude Code numbered menu."
+  (interactive)
+  (claude-code-ide--send-text "1"))
+
+;;;###autoload
+(defun claude-code-ide-send-2 ()
+  "Select the second option in a Claude Code numbered menu."
+  (interactive)
+  (claude-code-ide--send-text "2"))
+
+;;;###autoload
+(defun claude-code-ide-send-3 ()
+  "Select the third option in a Claude Code numbered menu."
+  (interactive)
+  (claude-code-ide--send-text "3"))
+
+;;;###autoload
+(defun claude-code-ide-cycle-mode ()
+  "Send Shift-Tab to Claude Code to cycle between modes.
+Claude cycles through default, auto-accept edits, and plan modes."
+  (interactive)
+  (claude-code-ide--with-terminal-buffer
+   (claude-code-ide--terminal-send-string "\e[Z")))
+
+;;;###autoload
+(defun claude-code-ide-fork ()
+  "Send escape-escape to Claude Code to jump to a previous message."
+  (interactive)
+  (claude-code-ide--with-terminal-buffer
+   (claude-code-ide--terminal-send-escape)
+   (sit-for 0.05)
+   (claude-code-ide--terminal-send-escape)))
+
+;;;###autoload
+(defun claude-code-ide-toggle-read-only-mode ()
+  "Toggle read-only/copy mode in the Claude Code terminal buffer.
+This makes the terminal navigable for selecting text without sending
+input to Claude.  Not supported for the ghostel backend."
+  (interactive)
+  (claude-code-ide--with-terminal-buffer
+   (setq claude-code-ide--read-only-active
+         (not claude-code-ide--read-only-active))
+   (claude-code-ide--terminal-set-read-only claude-code-ide--read-only-active)
+   (message "Claude Code read-only mode %s"
+            (if claude-code-ide--read-only-active "enabled" "disabled"))))
 
 ;;;###autoload
 (defun claude-code-ide-toggle ()

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -219,13 +219,6 @@ Diffs are enabled or disabled with `claude-code-ide-use-ide-diff'."
                  (const :tag "Simple (read-only diff-mode)" simple))
   :group 'claude-code-ide)
 
-(defcustom claude-code-ide-enable-keepalive nil
-  "Whether to send periodic WebSocket pings to keep the connection alive.
-Disabled by default.  Enable if long-idle sessions drop their connection;
-pings are sent every `claude-code-ide-mcp-ping-interval' seconds."
-  :type 'boolean
-  :group 'claude-code-ide)
-
 (defcustom claude-code-ide-enable-resources t
   "Whether to expose Emacs files to Claude Code as MCP resources.
 When non-nil (default), Claude Code can list and read open buffers,

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -204,6 +204,14 @@ display diffs in the terminal instead."
   :type 'boolean
   :group 'claude-code-ide)
 
+(defcustom claude-code-ide-enable-resources t
+  "Whether to expose Emacs files to Claude Code as MCP resources.
+When non-nil (default), Claude Code can list and read open buffers,
+recent files, and project files via the resources/list and
+resources/read MCP methods.  Set to nil to disable resource sharing."
+  :type 'boolean
+  :group 'claude-code-ide)
+
 (defcustom claude-code-ide-switch-tab-on-ediff t
   "Whether to switch back to Claude's original tab when opening ediff.
 When non-nil (default), Claude Code will switch back to the tab

--- a/claude-code-ide.el
+++ b/claude-code-ide.el
@@ -241,26 +241,6 @@ whole buffer would be sent."
   :type 'integer
   :group 'claude-code-ide)
 
-(defcustom claude-code-ide-enable-image-paste t
-  "Whether to enable image pasting via `yank-media' in Claude buffers.
-When non-nil, pasting an image into the Claude terminal writes it to a
-temporary file and inserts an @path reference at the prompt, which
-Claude's CLI reads natively.  Requires Emacs 29 or later."
-  :type 'boolean
-  :group 'claude-code-ide)
-
-(defcustom claude-code-ide-image-paste-directory
-  (if (file-directory-p "/tmp") "/tmp" temporary-file-directory)
-  "Directory where pasted images are written.
-Defaults to \"/tmp\" when available so the inserted @path stays short."
-  :type 'directory
-  :group 'claude-code-ide)
-
-(defcustom claude-code-ide-image-paste-cleanup-on-kill t
-  "Whether to delete pasted image temp files when the Claude buffer is killed."
-  :type 'boolean
-  :group 'claude-code-ide)
-
 (defcustom claude-code-ide-enable-notifications t
   "Whether to notify when Claude finishes and is awaiting input.
 Notifications are triggered by the terminal bell that Claude emits when
@@ -671,58 +651,6 @@ This function binds:
   (when-let ((name (if (stringp buffer) buffer (buffer-name buffer))))
     (string-prefix-p "*claude-code[" name)))
 
-;;; Image Pasting
-
-(defconst claude-code-ide--image-mime-extensions
-  '(("image/png" . ".png")
-    ("image/jpeg" . ".jpg")
-    ("image/jpg" . ".jpg")
-    ("image/gif" . ".gif")
-    ("image/webp" . ".webp")
-    ("image/bmp" . ".bmp"))
-  "Alist mapping image MIME-type prefix to file extension.")
-
-(defvar-local claude-code-ide--pasted-image-files nil
-  "List of temp image files pasted into this Claude buffer, for cleanup.")
-
-(defun claude-code-ide--image-extension-for-mimetype (mimetype)
-  "Return the file extension (including the dot) for MIMETYPE.
-MIMETYPE may be a symbol or a string.  Falls back to \".png\"."
-  (let* ((str (if (symbolp mimetype) (symbol-name mimetype) mimetype))
-         (match (seq-find (lambda (pair) (string-prefix-p (car pair) str))
-                          claude-code-ide--image-mime-extensions)))
-    (if match (cdr match) ".png")))
-
-(defun claude-code-ide--image-yank-media-handler (mimetype data)
-  "Handle an image paste in a Claude buffer.
-MIMETYPE is the MIME type (string or symbol); DATA is the raw bytes.
-Writes DATA to a temp file and injects an @path reference at the prompt."
-  (let* ((ext (claude-code-ide--image-extension-for-mimetype mimetype))
-         (temporary-file-directory claude-code-ide-image-paste-directory)
-         (path (make-temp-file "claude-image-" nil ext))
-         (coding-system-for-write 'binary))
-    (with-temp-file path (insert data))
-    (push path claude-code-ide--pasted-image-files)
-    (claude-code-ide--terminal-send-string (concat "@" path " "))
-    (message "Pasted image as %s" path)
-    t))
-
-(defun claude-code-ide--cleanup-pasted-images ()
-  "Delete temp image files created by `yank-media' in this buffer."
-  (when claude-code-ide-image-paste-cleanup-on-kill
-    (dolist (file claude-code-ide--pasted-image-files)
-      (when (file-exists-p file)
-        (ignore-errors (delete-file file))))
-    (setq claude-code-ide--pasted-image-files nil)))
-
-(defun claude-code-ide--register-image-yank-media-handler ()
-  "Register an image `yank-media-handler' in the current Claude buffer.
-No-op on Emacs versions without `yank-media-handler' (pre-29)."
-  (when (and claude-code-ide-enable-image-paste
-             (fboundp 'yank-media-handler))
-    (yank-media-handler "image/.*" #'claude-code-ide--image-yank-media-handler)
-    (add-hook 'kill-buffer-hook #'claude-code-ide--cleanup-pasted-images nil t)))
-
 ;;; Completion Notifications
 
 (defun claude-code-ide--pulse-modeline ()
@@ -764,9 +692,8 @@ are ignored."
   (funcall orig-fun process input))
 
 (defun claude-code-ide--setup-terminal-extras ()
-  "Set up image pasting and bell notifications in the current Claude buffer.
+  "Set up bell-based completion notifications in the current Claude buffer.
 Assumes the current buffer is the Claude terminal buffer."
-  (claude-code-ide--register-image-yank-media-handler)
   (when claude-code-ide-enable-notifications
     (cond
      ((eq claude-code-ide-terminal-backend 'vterm)

--- a/scripts/compile-and-test.sh
+++ b/scripts/compile-and-test.sh
@@ -67,6 +67,13 @@ if TRANSIENT_DIR=$(find_emacs_package "transient"); then
     LOAD_PATH="$LOAD_PATH -L $TRANSIENT_DIR"
 fi
 
+# Transitive dependencies of recent transient versions
+for dep in cond-let compat llama; do
+    if DEP_DIR=$(find_emacs_package "$dep"); then
+        LOAD_PATH="$LOAD_PATH -L $DEP_DIR"
+    fi
+done
+
 if VTERM_DIR=$(find_emacs_package "emacs-libvterm"); then
     LOAD_PATH="$LOAD_PATH -L $VTERM_DIR"
 fi
@@ -128,7 +135,7 @@ TEST_FAILED=0
 if [ $COMPILE_EXIT_CODE -eq 0 ] && [ $NATIVE_COMPILE_EXIT_CODE -eq 0 ]; then
     echo "" >&2
     echo "=== Running tests ===" >&2
-    emacs -batch -L . -l ert -l claude-code-ide-tests.el -f ert-run-tests-batch-and-exit >&2
+    emacs -batch $LOAD_PATH -l ert -l claude-code-ide-tests.el -f ert-run-tests-batch-and-exit >&2
     TEST_EXIT_CODE=$?
 
     if [ $TEST_EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
Ports the features in an alternative Claude Code plugin:
- https://github.com/stevemolitor/claude-code.el
- https://github.com/stevemolitor/monet

Includes:
- Send quick responses through transient
- Add IDE state tools and MCP resources support
- Pluggable diff backend
- Debug toggle