### PR TITLE
Render the session status header in the menu

### DIFF
--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -3713,6 +3713,34 @@ and pruning drops entries whose tab no longer exists."
             (should (memq other cleaned))))
       (claude-code-ide-tests--clear-processes))))
 
+(ert-deftest claude-code-ide-test-transient-descriptions-have-children ()
+  "Every menu group that carries a description also owns children.
+`transient--init-group' binds a group's children inside `and-let*', so a
+childless group is dropped whole and its description never reaches the
+buffer.  The session status header was invisible for exactly this reason.
+It is checked by name because it is the one that regressed."
+  (require 'claude-code-ide-transient)
+  (dolist (prefix '(claude-code-ide-menu
+                    claude-code-ide-config-menu
+                    claude-code-ide-debug-menu))
+    (let* ((layout (get prefix 'transient--layout))
+           ;; Transient wraps the group list in a [level _ groups] vector.
+           (groups (if (vectorp layout) (aref layout 2) layout)))
+      (should groups)
+      (dolist (group groups)
+        (when (plist-get (aref group 1) :description)
+          (should (> (length (aref group 2)) 0))))))
+  ;; The status header specifically must still be attached, and attached to
+  ;; a group that survives initialization.
+  (let* ((layout (get 'claude-code-ide-menu 'transient--layout))
+         (groups (if (vectorp layout) (aref layout 2) layout))
+         (header (seq-find (lambda (group)
+                             (eq (plist-get (aref group 1) :description)
+                                 'claude-code-ide--session-status))
+                           groups)))
+    (should header)
+    (should (> (length (aref header 2)) 0))))
+
 (provide 'claude-code-ide-tests)
 
 ;; Local Variables:

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -3713,33 +3713,63 @@ and pruning drops entries whose tab no longer exists."
             (should (memq other cleaned))))
       (claude-code-ide-tests--clear-processes))))
 
+(defun claude-code-ide-tests--transient-groups (layout)
+  "Return LAYOUT's groups as a list of (ARGS-PLIST . CHILDREN) pairs.
+Transient changed how it stores a parsed layout, so reading it by fixed
+index breaks across versions.  Before transient 0.9 a layout was a bare
+list of [LEVEL CLASS ARGS CHILDREN] groups; since then it is a
+[LEVEL _ GROUPS] vector holding [CLASS ARGS CHILDREN] groups.  Normalize
+both, so the caller can assert the invariant rather than the encoding."
+  (let ((groups (if (and (vectorp layout)
+                         (integerp (aref layout 0)))
+                    (aref layout 2)
+                  layout)))
+    (mapcar (lambda (group)
+              (pcase (length group)
+                (4 (cons (aref group 2) (aref group 3)))
+                (3 (cons (aref group 1) (aref group 2)))
+                (_ (cons nil nil))))
+            groups)))
+
+(ert-deftest claude-code-ide-test-transient-groups-normalizer ()
+  "The layout normalizer reads both transient encodings.
+Pins the helper the header test depends on, so a transient upgrade that
+changes the encoding fails here with a clear cause rather than as a
+puzzling assertion in the test below."
+  ;; Pre-0.9: bare list of [LEVEL CLASS ARGS CHILDREN] groups.
+  (should (equal (claude-code-ide-tests--transient-groups
+                  (list (vector 1 'transient-column '(:description foo) '(a b))))
+                 '(((:description foo) . (a b)))))
+  ;; 0.9 and later: [LEVEL _ GROUPS] holding [CLASS ARGS CHILDREN] groups.
+  (should (equal (claude-code-ide-tests--transient-groups
+                  (vector 2 nil (list (vector 'transient-column '(:description foo) '(a b)))))
+                 '(((:description foo) . (a b))))))
+
 (ert-deftest claude-code-ide-test-transient-descriptions-have-children ()
   "Every menu group that carries a description also owns children.
 `transient--init-group' binds a group's children inside `and-let*', so a
 childless group is dropped whole and its description never reaches the
-buffer.  The session status header was invisible for exactly this reason.
-It is checked by name because it is the one that regressed."
+buffer.  The session-status header was invisible for exactly this reason.
+The header is checked by name because it is the one that regressed."
   (require 'claude-code-ide-transient)
   (dolist (prefix '(claude-code-ide-menu
                     claude-code-ide-config-menu
                     claude-code-ide-debug-menu))
-    (let* ((layout (get prefix 'transient--layout))
-           ;; Transient wraps the group list in a [level _ groups] vector.
-           (groups (if (vectorp layout) (aref layout 2) layout)))
+    (let ((groups (claude-code-ide-tests--transient-groups
+                   (get prefix 'transient--layout))))
       (should groups)
-      (dolist (group groups)
-        (when (plist-get (aref group 1) :description)
-          (should (> (length (aref group 2)) 0))))))
+      (pcase-dolist (`(,args . ,children) groups)
+        (when (plist-get args :description)
+          (should children)))))
   ;; The status header specifically must still be attached, and attached to
   ;; a group that survives initialization.
-  (let* ((layout (get 'claude-code-ide-menu 'transient--layout))
-         (groups (if (vectorp layout) (aref layout 2) layout))
-         (header (seq-find (lambda (group)
-                             (eq (plist-get (aref group 1) :description)
-                                 'claude-code-ide--session-status))
-                           groups)))
+  (let ((header (seq-find (lambda (group)
+                            (eq (plist-get (car group) :description)
+                                'claude-code-ide--session-status))
+                          (claude-code-ide-tests--transient-groups
+                           (get 'claude-code-ide-menu 'transient--layout)))))
     (should header)
-    (should (> (length (aref header 2)) 0))))
+    (should (cdr header))))
 
 (provide 'claude-code-ide-tests)
 

--- a/claude-code-ide-transient.el
+++ b/claude-code-ide-transient.el
@@ -319,29 +319,32 @@
 ;;;###autoload (autoload 'claude-code-ide-menu "claude-code-ide-transient" "Claude Code IDE main menu." t)
 (transient-define-prefix claude-code-ide-menu ()
   "Claude Code IDE main menu."
-  [:description claude-code-ide--session-status]
-  ["Claude Code IDE"
-   ["Session Management"
-    ("s" claude-code-ide :description claude-code-ide--start-description)
-    ("c" "Continue in new instance" claude-code-ide-continue)
-    ("r" "Resume in new instance" claude-code-ide-resume)
-    ("q" "Stop instance" claude-code-ide-stop)
-    ("Q" "Stop all instances" claude-code-ide-stop-all)
-    ("R" "Rename instance" claude-code-ide-rename-session)
-    ("l" "List all sessions" claude-code-ide-list-sessions)]
-   ["Navigation"
-    ("b" "Switch to Claude buffer" claude-code-ide-switch-to-buffer)
-    ("w" "Toggle project windows" claude-code-ide-toggle)
-    ("W" "Toggle all windows" claude-code-ide-toggle-recent)
-    ("a" "Show all instances" claude-code-ide-show-all)]
-   ["Interaction"
-    ("i" "Insert selection" claude-code-ide-insert-at-mentioned)
-    ("p" "Send prompt from minibuffer" claude-code-ide-send-prompt)
-    ("e" "Send escape key" claude-code-ide-send-escape)
-    ("n" "Insert newline" claude-code-ide-insert-newline)]
-   ["Submenus"
-    ("C" "Configuration" claude-code-ide-config-menu)
-    ("d" "Debugging" claude-code-ide-debug-menu)]])
+  ;; The description rides on the group that owns the columns rather than a
+  ;; group of its own.  `transient--init-group' binds a group's children
+  ;; inside `and-let*', so a childless group is dropped whole and its
+  ;; description never reaches the buffer.
+  [:description claude-code-ide--session-status
+                ["Session Management"
+                 ("s" claude-code-ide :description claude-code-ide--start-description)
+                 ("c" "Continue in new instance" claude-code-ide-continue)
+                 ("r" "Resume in new instance" claude-code-ide-resume)
+                 ("q" "Stop instance" claude-code-ide-stop)
+                 ("Q" "Stop all instances" claude-code-ide-stop-all)
+                 ("R" "Rename instance" claude-code-ide-rename-session)
+                 ("l" "List all sessions" claude-code-ide-list-sessions)]
+                ["Navigation"
+                 ("b" "Switch to Claude buffer" claude-code-ide-switch-to-buffer)
+                 ("w" "Toggle project windows" claude-code-ide-toggle)
+                 ("W" "Toggle all windows" claude-code-ide-toggle-recent)
+                 ("a" "Show all instances" claude-code-ide-show-all)]
+                ["Interaction"
+                 ("i" "Insert selection" claude-code-ide-insert-at-mentioned)
+                 ("p" "Send prompt from minibuffer" claude-code-ide-send-prompt)
+                 ("e" "Send escape key" claude-code-ide-send-escape)
+                 ("n" "Insert newline" claude-code-ide-insert-newline)]
+                ["Submenus"
+                 ("C" "Configuration" claude-code-ide-config-menu)
+                 ("d" "Debugging" claude-code-ide-debug-menu)]])
 
 (transient-define-prefix claude-code-ide-config-menu ()
   "Claude Code configuration menu."


### PR DESCRIPTION
The session status header in `claude-code-ide-menu` is never drawn.

## Cause

The header is defined as a group of its own:

```elisp
[:description claude-code-ide--session-status]
```

That group has no children. `transient--init-group` binds a group's children inside `and-let*`:

```elisp
(and-let* (((transient--use-level-p level))
           (obj (apply class :parent parent :level level args))
           ...
           (suffixes (mapcan #'... (transient-setup-children obj children))))
  (progn (oset obj suffixes suffixes)
         (list obj)))
```

With no children, `mapcan` returns nil, the `and-let*` short-circuits, and the group is dropped before rendering — description included. The `:around` method that would insert the description never runs.

This is long-standing, deliberate transient behavior, not a regression. Childless groups have been pruned since transient v0.3.0 (2021); only the spelling changed, from `when-let` to `and-let*`. v0.9.3 was the current release when the header was added in 3449f5b, and it already pruned, so the header has not rendered on any released transient.

## Impact

`claude-code-ide--session-status` itself is correct. Called directly it returns:

```
myproject — 2 instances (2 connected)
  myproject:2  port 17575  connected  visible
  myproject    port 56945  connected  visible
```

None of it reaches the screen. This matters more in 0.3.0, whose notes describe a menu that lists instances with port, connection and visibility state.

## Fix

Move the description onto the group that owns the four columns. That group has children, so it survives initialization. The static `"Claude Code IDE"` title gives way to the live status line the header was there to show.

Ignoring the reindentation that follows from re-parenting, the change is:

```diff
-  [:description claude-code-ide--session-status]
-  ["Claude Code IDE"
+  [:description claude-code-ide--session-status
      ["Session Management"
```

## Test

`claude-code-ide-test-transient-descriptions-have-children` asserts the invariant across every prefix — no group carries a description without children — plus a named check that the status header is still attached to a group that survives. Reverting the layout makes it fail.

## Verification

- Suite before: 103 passed, exit 0
- Suite after: 104 passed, 0 failed, exit 0
- New test passes; mutating the layout back makes it fail
- `claude-code-ide-transient.el` byte-compiles with no new warnings
- Checked against transient 0.13.5 and the built-in v0.13.3