### PR TITLE
Honor CLAUDE_CONFIG_DIR for the lockfile directory

### DIFF
--- a/claude-code-ide-mcp.el
+++ b/claude-code-ide-mcp.el
@@ -206,8 +206,24 @@ used session."
 ;;; Lockfile Management
 
 (defun claude-code-ide-mcp--lockfile-directory ()
-  "Return the directory for MCP lockfiles."
-  (expand-file-name "~/.claude/ide/"))
+  "Return the directory for MCP lockfiles.
+The Claude Code CLI discovers the MCP server by scanning this directory for
+`<port>.lock' files, so both sides must agree on it.  The CLI derives it from
+the `CLAUDE_CONFIG_DIR' environment variable, defaulting to `~/.claude'; we
+mirror that here.  Since the CLI runs as a subprocess of Emacs and inherits
+this environment, setting `CLAUDE_CONFIG_DIR' relocates the lockfile on both
+sides in lockstep.
+
+An empty `CLAUDE_CONFIG_DIR' is treated as unset (matching the wider Claude
+Code convention), so a misconfigured shell does not resolve the lockfile
+relative to `default-directory'."
+  (let ((config-dir (getenv "CLAUDE_CONFIG_DIR")))
+    (expand-file-name
+     "ide/"
+     (file-name-as-directory
+      (if (and config-dir (not (string= config-dir "")))
+          config-dir
+        "~/.claude")))))
 
 (defun claude-code-ide-mcp--lockfile-path (port)
   "Return the lockfile path for PORT."

--- a/claude-code-ide-tests.el
+++ b/claude-code-ide-tests.el
@@ -3713,6 +3713,24 @@ and pruning drops entries whose tab no longer exists."
             (should (memq other cleaned))))
       (claude-code-ide-tests--clear-processes))))
 
+(ert-deftest claude-code-ide-test-mcp-lockfile-directory-resolution ()
+  "Test that the lockfile directory honors `CLAUDE_CONFIG_DIR'."
+  (require 'claude-code-ide-mcp)
+  ;; Unset: defaults to ~/.claude/ide/.
+  (let ((process-environment (cons "CLAUDE_CONFIG_DIR" process-environment)))
+    (should (equal (claude-code-ide-mcp--lockfile-directory)
+                   (expand-file-name "~/.claude/ide/"))))
+  ;; Set without a trailing slash: still resolves under that directory.
+  (let ((process-environment (cons "CLAUDE_CONFIG_DIR=/tmp/cc-config" process-environment)))
+    (should (equal (claude-code-ide-mcp--lockfile-directory)
+                   "/tmp/cc-config/ide/")))
+  ;; Set but empty: treated as unset, must not resolve relative to
+  ;; `default-directory'.
+  (let ((process-environment (cons "CLAUDE_CONFIG_DIR=" process-environment))
+        (default-directory "/some/project/"))
+    (should (equal (claude-code-ide-mcp--lockfile-directory)
+                   (expand-file-name "~/.claude/ide/")))))
+
 (provide 'claude-code-ide-tests)
 
 ;; Local Variables:


### PR DESCRIPTION
`claude-code-ide-mcp--lockfile-directory` hardcodes `~/.claude/ide/`, so a session cannot start anywhere `$HOME` or `~/.claude/ide/` is read-only — sandboxes, containers, and locked-down CI images.

## Fix

The Claude Code CLI locates IDE lockfiles under `CLAUDE_CONFIG_DIR`, defaulting to `~/.claude`. Mirror that resolution in Emacs:

```elisp
(let ((config-dir (getenv "CLAUDE_CONFIG_DIR")))
  (expand-file-name
   "ide/"
   (file-name-as-directory
    (if (and config-dir (not (string= config-dir "")))
        config-dir
      "~/.claude"))))
```

The CLI runs as a subprocess of Emacs and inherits its environment, so setting the variable relocates the lockfile on both sides together. The two cannot drift.

An empty value is treated as unset. A shell exporting `CLAUDE_CONFIG_DIR=` would otherwise make `expand-file-name` resolve the lockfile against `default-directory`, putting it somewhere the CLI never scans — a silent failure to connect, rather than a visible error.

## Attribution

This patch is not mine. It originates from the [emlautarom1 fork](https://github.com/emlautarom1/claude-code-ide.el), authored by `emlautarom1-agent[bot]`, and I have preserved that authorship on the commit. I carry it in my own fork, hit the underlying problem, and saw no corresponding PR or issue here — so I am forwarding it rather than letting it sit in a fork. Happy to close this if the original author would prefer to submit it themselves.

## Test

`claude-code-ide-test-mcp-lockfile-directory-resolution` covers all three states: unset, set without a trailing slash, and set-but-empty. It calls the function directly, so it needs no server or filesystem.

## Verification

- Suite before: 103 passed, exit 0
- Suite after: **104 passed, 0 failed, exit 0**
- Reverting the source change makes the new test fail
- `claude-code-ide-mcp.el` byte-compiles with **20 warnings before and 20 after** — this change adds none, and none mention the touched function

## Not included

The source fork also wraps the tests that create real lockfiles in a `with-temp-config-dir` helper, so the suite runs where `$HOME` is read-only. That touches unrelated tests, so I left it out to keep this reviewable. Glad to add it if you want the suite sandbox-safe too.
